### PR TITLE
fix: implement stream cancellation mechanism

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,9 @@ rusqlite = { version = "0.30", features = ["bundled"] }
 keyring = { version = "3.6", features = ["windows-native", "apple-native", "linux-native"] }
 sha2 = "0.10"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+tokio-util = { version = "0.7", features = ["sync"] }
+once_cell = "1.19"
+scopeguard = "1.2"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -6,10 +6,15 @@ use crate::commands::mcp::{get_all_mcp_tools, call_mcp_tool, MCPTool};
 use crate::db::DbState;
 use chrono::Utc;
 use futures::StreamExt;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tauri::{AppHandle, Emitter};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 // Types
@@ -54,6 +59,10 @@ pub struct StreamChunk {
     pub content: String,
     pub done: bool,
 }
+
+// Global storage for active stream cancellation tokens
+static ACTIVE_STREAMS: Lazy<Arc<Mutex<HashMap<String, CancellationToken>>>> = 
+    Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
 
 // Errors
 #[allow(dead_code)]
@@ -377,6 +386,22 @@ pub async fn stream_message(
 ) -> Result<(), LLMError> {
     let api_key = get_api_key(&request)?;
     let message_id = Uuid::new_v4().to_string();
+    let session_id = request.session_id.clone();
+    
+    // Create cancellation token and store it
+    let cancel_token = CancellationToken::new();
+    {
+        let mut streams = ACTIVE_STREAMS.lock().await;
+        streams.insert(session_id.clone(), cancel_token.clone());
+    }
+    
+    // Cleanup token when function exits
+    let _cleanup = scopeguard::guard(session_id.clone(), |sid| {
+        tauri::async_runtime::spawn(async move {
+            let mut streams = ACTIVE_STREAMS.lock().await;
+            streams.remove(&sid);
+        });
+    });
     
     // Get MCP tools if enabled
     let mcp_tools = if request.enable_mcp {
@@ -456,119 +481,144 @@ pub async fn stream_message(
     let mut buffer = String::new();
     let mut accumulated_tool_calls = Vec::new();
 
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e: reqwest::Error| LLMError::StreamError(e.to_string()))?;
-        let text = String::from_utf8_lossy(&chunk);
-        buffer.push_str(&text);
-
-        // Process complete lines
-        while let Some(pos) = buffer.find('\n') {
-            let line = buffer[..pos].trim().to_string();
-            buffer = buffer[pos + 1..].to_string();
-
-            if line.is_empty() {
-                continue;
+    // Main loop with cancellation support
+    loop {
+        tokio::select! {
+            // Check for cancellation signal
+            _ = cancel_token.cancelled() => {
+                log::info!("Stream cancelled for session: {}", session_id);
+                // Emit done event to notify frontend
+                let _ = app_handle.emit("stream-chunk", StreamChunk {
+                    session_id: request.session_id.clone(),
+                    message_id: message_id.clone(),
+                    content: String::new(),
+                    done: true,
+                });
+                return Ok(());
             }
+            // Read next chunk from stream
+            chunk = stream.next() => {
+                match chunk {
+                    Some(Ok(chunk)) => {
+                        let text = String::from_utf8_lossy(&chunk);
+                        buffer.push_str(&text);
 
-            if let Some(content) = parse_sse_line(&request.provider, &line) {
-                match content {
-                    StreamContent::Text(text) => {
-                        let _ = app_handle.emit("stream-chunk", StreamChunk {
-                            session_id: request.session_id.clone(),
-                            message_id: message_id.clone(),
-                            content: text,
-                            done: false,
-                        });
-                    }
-                    StreamContent::ToolCalls(calls) => {
-                        accumulated_tool_calls.extend(calls);
-                    }
-                    StreamContent::Done => {
-                        // Process accumulated tool calls if any
-                        if !accumulated_tool_calls.is_empty() && request.enable_mcp {
-                            let tool_calls = std::mem::take(&mut accumulated_tool_calls);
-                            for tool_call in tool_calls {
-                                // Find the tool and execute it
-                                if let Some(tool) = mcp_tools.iter().find(|t| t.name == tool_call.function.name) {
-                                    log::info!("Executing MCP tool: {}", tool.name);
-                                    
-                                    match call_mcp_tool(
-                                        state.clone(),
-                                        Some(tool.server_id.clone()),
-                                        tool.name.clone(),
-                                        serde_json::from_str(&tool_call.function.arguments).unwrap_or(serde_json::Value::Null),
-                                    ).await {
-                                        Ok(result) => {
-                                            log::info!("Tool execution result: {:?}", result);
+                        // Process complete lines
+                        while let Some(pos) = buffer.find('\n') {
+                            let line = buffer[..pos].trim().to_string();
+                            buffer = buffer[pos + 1..].to_string();
 
-                                            // Send tool result back to the LLM for continued reasoning
-                                            let tool_result_content = format!(
-                                                "工具 {} 调用结果：{}",
-                                                tool.name,
-                                                serde_json::to_string(&result).unwrap_or_else(|_| "<serialize error>".to_string())
-                                            );
+                            if line.is_empty() {
+                                continue;
+                            }
 
-                                            let mut follow_up_messages = request.messages.clone();
-                                            follow_up_messages.push(ChatMessage {
-                                                id: Uuid::new_v4().to_string(),
-                                                role: "assistant".to_string(),
-                                                content: tool_result_content.clone(),
-                                                timestamp: Utc::now().timestamp_millis(),
-                                                error: None,
-                                            });
+                            if let Some(content) = parse_sse_line(&request.provider, &line) {
+                                match content {
+                                    StreamContent::Text(text) => {
+                                        let _ = app_handle.emit("stream-chunk", StreamChunk {
+                                            session_id: request.session_id.clone(),
+                                            message_id: message_id.clone(),
+                                            content: text,
+                                            done: false,
+                                        });
+                                    }
+                                    StreamContent::ToolCalls(calls) => {
+                                        accumulated_tool_calls.extend(calls);
+                                    }
+                                    StreamContent::Done => {
+                                        // Process accumulated tool calls if any
+                                        if !accumulated_tool_calls.is_empty() && request.enable_mcp {
+                                            let tool_calls = std::mem::take(&mut accumulated_tool_calls);
+                                            for tool_call in tool_calls {
+                                                // Find the tool and execute it
+                                                if let Some(tool) = mcp_tools.iter().find(|t| t.name == tool_call.function.name) {
+                                                    log::info!("Executing MCP tool: {}", tool.name);
+                                                    
+                                                    match call_mcp_tool(
+                                                        state.clone(),
+                                                        Some(tool.server_id.clone()),
+                                                        tool.name.clone(),
+                                                        serde_json::from_str(&tool_call.function.arguments).unwrap_or(serde_json::Value::Null),
+                                                    ).await {
+                                                        Ok(result) => {
+                                                            log::info!("Tool execution result: {:?}", result);
 
-                                            match request_llm_once(
-                                                &request.provider,
-                                                &request.model,
-                                                &request.api_key,
-                                                &request.base_url,
-                                                &follow_up_messages,
-                                                &mcp_tools,
-                                            )
-                                            .await
-                                            {
-                                                Ok(live_reply) => {
-                                                    let _ = app_handle.emit("stream-chunk", StreamChunk {
-                                                        session_id: request.session_id.clone(),
-                                                        message_id: message_id.clone(),
-                                                        content: live_reply,
-                                                        done: false,
-                                                    });
-                                                }
-                                                Err(err) => {
-                                                    log::error!("Failed to continue reasoning after tool call: {}", err);
+                                                            // Send tool result back to the LLM for continued reasoning
+                                                            let tool_result_content = format!(
+                                                                "工具 {} 调用结果：{}",
+                                                                tool.name,
+                                                                serde_json::to_string(&result).unwrap_or_else(|_| "<serialize error>".to_string())
+                                                            );
+
+                                                            let mut follow_up_messages = request.messages.clone();
+                                                            follow_up_messages.push(ChatMessage {
+                                                                id: Uuid::new_v4().to_string(),
+                                                                role: "assistant".to_string(),
+                                                                content: tool_result_content.clone(),
+                                                                timestamp: Utc::now().timestamp_millis(),
+                                                                error: None,
+                                                            });
+
+                                                            match request_llm_once(
+                                                                &request.provider,
+                                                                &request.model,
+                                                                &request.api_key,
+                                                                &request.base_url,
+                                                                &follow_up_messages,
+                                                                &mcp_tools,
+                                                            )
+                                                            .await
+                                                            {
+                                                                Ok(live_reply) => {
+                                                                    let _ = app_handle.emit("stream-chunk", StreamChunk {
+                                                                        session_id: request.session_id.clone(),
+                                                                        message_id: message_id.clone(),
+                                                                        content: live_reply,
+                                                                        done: false,
+                                                                    });
+                                                                }
+                                                                Err(err) => {
+                                                                    log::error!("Failed to continue reasoning after tool call: {}", err);
+                                                                }
+                                                            }
+                                                        }
+                                                        Err(e) => {
+                                                            log::error!("Tool execution failed: {}", e);
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
-                                        Err(e) => {
-                                            log::error!("Tool execution failed: {}", e);
-                                        }
+                                        
+                                        let _ = app_handle.emit("stream-chunk", StreamChunk {
+                                            session_id: request.session_id.clone(),
+                                            message_id: message_id.clone(),
+                                            content: String::new(),
+                                            done: true,
+                                        });
+                                        return Ok(());
                                     }
                                 }
                             }
                         }
-                        
+                    }
+                    Some(Err(e)) => {
+                        return Err(LLMError::StreamError(e.to_string()));
+                    }
+                    None => {
+                        // Stream ended naturally
                         let _ = app_handle.emit("stream-chunk", StreamChunk {
                             session_id: request.session_id.clone(),
                             message_id: message_id.clone(),
                             content: String::new(),
                             done: true,
                         });
+                        return Ok(());
                     }
                 }
             }
         }
     }
-
-    // Emit final done event
-    let _ = app_handle.emit("stream-chunk", StreamChunk {
-        session_id: request.session_id,
-        message_id,
-        content: String::new(),
-        done: true,
-    });
-
-    Ok(())
 }
 
 async fn request_llm_once(
@@ -685,4 +735,17 @@ fn get_api_key(request: &SendMessageRequest) -> Result<String, LLMError> {
         return Err(LLMError::MissingApiKey);
     }
     Ok(request.api_key.clone())
+}
+
+/// Cancel an active stream for a session
+#[tauri::command]
+pub async fn cancel_stream(session_id: String) -> Result<(), String> {
+    let mut streams = ACTIVE_STREAMS.lock().await;
+    if let Some(token) = streams.get(&session_id) {
+        token.cancel();
+        log::info!("Cancelled stream for session: {}", session_id);
+        Ok(())
+    } else {
+        Err("No active stream found for session".to_string())
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             // LLM commands
             commands::llm::stream_message,
+            commands::llm::cancel_stream,
             // Auth commands
             commands::auth::get_baidu_access_token,
             // Database commands

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -753,16 +753,30 @@ ${toolDefs}
   };
 
   // ============ 流式中断功能 ============
-  const stopStream = () => {
-    if (isLoading.value && currentSession.value) {
-      isLoading.value = false;
-      const lastMessage = currentSession.value.messages[currentSession.value.messages.length - 1];
-      if (lastMessage && lastMessage.role === "assistant") {
-        lastMessage.streaming = false;
-      }
-      currentStreamContent.value = "";
-      console.log("[Stream] Stopped by user");
+  const stopStream = async () => {
+    if (!isLoading.value || !currentSession.value) return;
+    
+    const sessionId = currentSession.value.id;
+    
+    // Call backend to cancel the stream
+    try {
+      await invoke("cancel_stream", { sessionId });
+      console.log("[Stream] Cancellation request sent to backend");
+    } catch (error) {
+      // Log warning but continue with frontend cleanup
+      console.warn("[Stream] Failed to cancel stream on backend:", error);
     }
+    
+    // Update frontend state
+    isLoading.value = false;
+    const lastMessage = currentSession.value.messages[currentSession.value.messages.length - 1];
+    if (lastMessage && lastMessage.role === "assistant") {
+      lastMessage.streaming = false;
+      // Save the partial message to database
+      await saveMessageToDb(lastMessage);
+    }
+    currentStreamContent.value = "";
+    console.log("[Stream] Stopped by user");
   };
 
   // ============ 返回公共接口 ============


### PR DESCRIPTION
## Description

This PR implements a proper stream cancellation mechanism to fix issue #23. Previously, when users clicked the stop button, the frontend would only set a state flag while the backend continued processing the LLM stream, wasting resources.

## Changes

### Backend (`src-tauri/src/commands/llm.rs`)
- Added `CancellationToken` support using `tokio-util`
- Added global `ACTIVE_STREAMS` HashMap to track active streams per session
- Modified `stream_message` to use `tokio::select!` for listening to cancellation signals
- Added new `cancel_stream` command to allow frontend to cancel active streams

### Frontend (`src/stores/chat.ts`)
- Updated `stopStream` to be async and call the backend `cancel_stream` command
- Added error handling with graceful degradation
- Saves partial message to database when stream is stopped

### Dependencies (`src-tauri/Cargo.toml`)
- Added `tokio-util` for `CancellationToken`
- Added `once_cell` for lazy static initialization
- Added `scopeguard` for cleanup guarantees

### Main (`src-tauri/src/main.rs`)
- Registered the new `cancel_stream` command

## How It Works

1. When `stream_message` is called, it creates a `CancellationToken` and stores it in `ACTIVE_STREAMS` keyed by session ID
2. The stream processing loop uses `tokio::select!` to simultaneously:
   - Listen for cancellation signals
   - Read the next chunk from the HTTP stream
3. When user clicks stop, frontend calls `cancel_stream` which triggers the token
4. Backend immediately stops reading from the HTTP connection and emits a done event
5. Token is automatically cleaned up using `scopeguard`

## Testing

- [ ] Start a conversation and click stop button - stream should stop immediately
- [ ] Check logs for "Stream cancelled for session" message
- [ ] Verify partial response is saved to database
- [ ] Test with multiple concurrent sessions to ensure isolation

## Related Issue

Fixes #23