### PR TITLE
feat: 本地模型部署功能 - Ollama 集成与多源下载支持

### DIFF
--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -146,6 +146,7 @@ impl Serialize for LLMError {
     ("siliconflow", "https://api.siliconflow.cn/v1/chat/completions", "bearer"),
     ("minimax", "https://api.minimax.chat/v1/text/chatcompletion_v2", "bearer"),
     ("yi", "https://api.lingyiwanwu.com/v1/chat/completions", "bearer"),
+    ("local", "", "none"),
     ("custom", "", "bearer"),
 ];
 
@@ -171,6 +172,7 @@ fn build_url(provider: &str, base_url: &str, model: &str) -> String {
             }
         }
         "custom" => format!("{}/chat/completions", base_url.trim_end_matches('/')),
+        "local" => format!("{}/chat/completions", base_url.trim_end_matches('/')),
         _ => {
             if let Some((_, url, _)) = PROVIDER_CONFIGS.iter().find(|(p, _, _)| *p == provider) {
                 url.to_string()
@@ -297,6 +299,10 @@ fn build_headers(provider: &str, api_key: &str) -> reqwest::header::HeaderMap {
         "anthropic" => {
             headers.insert("x-api-key", api_key.parse().unwrap());
             headers.insert("anthropic-version", "2023-06-01".parse().unwrap());
+        }
+        "local" => {
+            // Local models (e.g. Ollama) don't require authentication
+            // No Authorization header needed
         }
         _ => {
             headers.insert(
@@ -775,6 +781,10 @@ pub async fn delete_chat_session(session_id: String) -> Result<(), LLMError> {
 }
 
 fn get_api_key(request: &SendMessageRequest) -> Result<String, LLMError> {
+    // Local models don't require API keys
+    if request.provider == "local" {
+        return Ok(String::new());
+    }
     if request.api_key.is_empty() {
         return Err(LLMError::MissingApiKey);
     }

--- a/src-tauri/src/commands/local_model.rs
+++ b/src-tauri/src/commands/local_model.rs
@@ -1,0 +1,427 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Local model management module
+//!
+//! Provides commands for managing locally deployed models via Ollama API.
+//! Supports multiple model sources (Ollama official, HuggingFace, ModelScope)
+//! for downloading/pulling models.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+
+// ============ Types ============
+
+/// Information about a locally available model from Ollama
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalModelInfo {
+    pub name: String,
+    /// Model display name (e.g. "llama3:latest")
+    pub model: String,
+    /// Modified timestamp
+    pub modified_at: String,
+    /// Model size in bytes
+    pub size: u64,
+    /// Model digest hash
+    pub digest: String,
+    /// Model details (family, parameter size, quantization level)
+    pub details: Option<ModelDetails>,
+}
+
+/// Detailed model information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelDetails {
+    pub parent_model: Option<String>,
+    pub format: Option<String>,
+    pub family: Option<String>,
+    pub families: Option<Vec<String>>,
+    pub parameter_size: Option<String>,
+    pub quantization_level: Option<String>,
+}
+
+/// Ollama API response for listing models
+#[derive(Debug, Deserialize)]
+struct OllamaListResponse {
+    models: Vec<OllamaModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaModelEntry {
+    name: String,
+    model: String,
+    modified_at: String,
+    size: u64,
+    digest: String,
+    details: Option<ModelDetails>,
+}
+
+/// Ollama API response for model show
+#[derive(Debug, Deserialize)]
+struct OllamaShowResponse {
+    details: Option<ModelDetails>,
+    // Other fields we don't need
+    #[allow(dead_code)]
+    license: Option<String>,
+    #[allow(dead_code)]
+    modelfile: Option<String>,
+    #[allow(dead_code)]
+    parameters: Option<String>,
+    #[allow(dead_code)]
+    template: Option<String>,
+}
+
+/// Model source configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelSource {
+    /// Unique identifier for the source
+    pub id: String,
+    /// Display name
+    pub name: String,
+    /// Base URL for the model registry
+    pub base_url: String,
+    /// Description
+    pub description: String,
+}
+
+/// Download progress event emitted to frontend
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadProgress {
+    pub model_name: String,
+    pub status: String,
+    pub digest: String,
+    pub total: Option<u64>,
+    pub completed: Option<u64>,
+}
+
+/// Pull request parameters
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PullModelRequest {
+    /// Model name (e.g. "llama3:latest" or "huggingface/user/model:tag")
+    pub model_name: String,
+    /// Source ID to pull from (optional, uses configured default)
+    pub source_id: Option<String>,
+    /// Whether to use insecure connection
+    pub insecure: Option<bool>,
+}
+
+/// Delete request parameters
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteModelRequest {
+    /// Model name to delete
+    pub model_name: String,
+}
+
+/// Configuration for local model service
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalModelConfig {
+    /// Ollama service base URL
+    pub ollama_base_url: String,
+    /// Default model source ID
+    pub default_source_id: String,
+}
+
+/// Predefined model sources
+pub fn get_model_sources() -> Vec<ModelSource> {
+    vec![
+        ModelSource {
+            id: "ollama".to_string(),
+            name: "Ollama 官方".to_string(),
+            base_url: "https://registry.ollama.ai".to_string(),
+            description: "Ollama 官方模型库，包含主流开源模型".to_string(),
+        },
+        ModelSource {
+            id: "huggingface".to_string(),
+            name: "HuggingFace".to_string(),
+            base_url: "https://huggingface.co".to_string(),
+            description: "全球最大的开源模型社区".to_string(),
+        },
+        ModelSource {
+            id: "modelscope".to_string(),
+            name: "ModelScope (魔搭)".to_string(),
+            base_url: "https://modelscope.cn".to_string(),
+            description: "阿里巴巴达摩院开源模型社区".to_string(),
+        },
+    ]
+}
+
+// ============ Helper functions ============
+
+/// Create HTTP client for Ollama API calls
+fn create_ollama_client(_base_url: &str) -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(300))
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+}
+
+/// Build Ollama API URL from base URL and endpoint
+fn build_ollama_url(base_url: &str, endpoint: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    format!("{}{}", base, endpoint)
+}
+
+// ============ Tauri Commands ============
+
+/// Check if Ollama service is running and accessible
+#[tauri::command]
+pub async fn check_ollama_status(
+    ollama_base_url: String,
+) -> Result<bool, String> {
+    let client = create_ollama_client(&ollama_base_url)
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let url = build_ollama_url(&ollama_base_url, "/api/tags");
+
+    match client.get(&url).send().await {
+        Ok(response) => Ok(response.status().is_success()),
+        Err(e) => {
+            log::debug!("Ollama status check failed: {}", e);
+            Ok(false)
+        }
+    }
+}
+
+/// List all locally available models from Ollama
+#[tauri::command]
+pub async fn list_local_models(
+    ollama_base_url: String,
+) -> Result<Vec<LocalModelInfo>, String> {
+    let client = create_ollama_client(&ollama_base_url)
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let url = build_ollama_url(&ollama_base_url, "/api/tags");
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to connect to Ollama: {}", e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Ollama returned status: {}", response.status()));
+    }
+
+    let body: OllamaListResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Ollama response: {}", e))?;
+
+    let models: Vec<LocalModelInfo> = body
+        .models
+        .into_iter()
+        .map(|m| LocalModelInfo {
+            name: m.name.clone(),
+            model: m.model,
+            modified_at: m.modified_at,
+            size: m.size,
+            digest: m.digest,
+            details: m.details,
+        })
+        .collect();
+
+    Ok(models)
+}
+
+/// Get detailed information about a specific local model
+#[tauri::command]
+pub async fn show_local_model(
+    ollama_base_url: String,
+    model_name: String,
+) -> Result<LocalModelInfo, String> {
+    let client = create_ollama_client(&ollama_base_url)
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let url = build_ollama_url(&ollama_base_url, "/api/show");
+
+    let response = client
+        .post(&url)
+        .json(&serde_json::json!({ "name": model_name }))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to connect to Ollama: {}", e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Ollama returned status: {}", response.status()));
+    }
+
+    let body: OllamaShowResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Ollama response: {}", e))?;
+
+    Ok(LocalModelInfo {
+        name: model_name.clone(),
+        model: model_name,
+        modified_at: String::new(),
+        size: 0,
+        digest: String::new(),
+        details: body.details,
+    })
+}
+
+/// Pull (download) a model from a specified source
+/// Emits download progress events to the frontend
+#[tauri::command]
+pub async fn pull_local_model(
+    request: PullModelRequest,
+    ollama_base_url: String,
+    app_handle: AppHandle,
+) -> Result<(), String> {
+    let client = create_ollama_client(&ollama_base_url)
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let url = build_ollama_url(&ollama_base_url, "/api/pull");
+
+    // Build the model name with source prefix if needed
+    let model_ref = match request.source_id.as_deref() {
+        Some("huggingface") => {
+            // HuggingFace format: hf.co/user/model:tag or hf.co/user/model
+            if !request.model_name.starts_with("hf.co/") {
+                format!("hf.co/{}", request.model_name)
+            } else {
+                request.model_name.clone()
+            }
+        }
+        Some("modelscope") => {
+            // ModelScope format: ms://user/model or just the model name
+            // Ollama supports pulling from ModelScope via the model name
+            request.model_name.clone()
+        }
+        _ => {
+            // Default: Ollama official registry
+            request.model_name.clone()
+        }
+    };
+
+    let mut body = serde_json::json!({
+        "name": model_ref,
+        "stream": true,
+    });
+
+    if request.insecure.unwrap_or(false) {
+        body["insecure"] = serde_json::json!(true);
+    }
+
+    log::info!("Pulling model: {}", model_ref);
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to start model pull: {}", e))?;
+
+    if !response.status().is_success() {
+        let error_text = response.text().await.unwrap_or_default();
+        return Err(format!("Pull failed: {}", error_text));
+    }
+
+    // Process streaming response for progress updates
+    use futures::StreamExt;
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Stream error during pull: {}", e))?;
+        let text = String::from_utf8_lossy(&chunk);
+        buffer.push_str(&text);
+
+        while let Some(pos) = buffer.find('\n') {
+            let line = buffer[..pos].trim().to_string();
+            buffer = buffer[pos + 1..].to_string();
+
+            if line.is_empty() {
+                continue;
+            }
+
+            if let Ok(progress) = serde_json::from_str::<serde_json::Value>(&line) {
+                let status = progress["status"].as_str().unwrap_or("unknown").to_string();
+                let digest = progress["digest"].as_str().unwrap_or("").to_string();
+                let total = progress["total"].as_u64();
+                let completed = progress["completed"].as_u64();
+
+                let _ = app_handle.emit("download-progress", DownloadProgress {
+                    model_name: request.model_name.clone(),
+                    status,
+                    digest,
+                    total,
+                    completed,
+                });
+            }
+        }
+    }
+
+    log::info!("Model pull completed: {}", request.model_name);
+    Ok(())
+}
+
+/// Delete a local model from Ollama
+#[tauri::command]
+pub async fn delete_local_model(
+    request: DeleteModelRequest,
+    ollama_base_url: String,
+) -> Result<(), String> {
+    let client = create_ollama_client(&ollama_base_url)
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let url = build_ollama_url(&ollama_base_url, "/api/delete");
+
+    let response = client
+        .delete(&url)
+        .json(&serde_json::json!({ "name": request.model_name }))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to delete model: {}", e))?;
+
+    if !response.status().is_success() {
+        let error_text = response.text().await.unwrap_or_default();
+        return Err(format!("Delete failed: {}", error_text));
+    }
+
+    log::info!("Model deleted: {}", request.model_name);
+    Ok(())
+}
+
+/// Get the list of available model sources
+#[tauri::command]
+pub async fn get_model_sources_cmd() -> Result<Vec<ModelSource>, String> {
+    Ok(get_model_sources())
+}
+
+/// Get Ollama version info
+#[tauri::command]
+pub async fn get_ollama_version(
+    ollama_base_url: String,
+) -> Result<String, String> {
+    let client = create_ollama_client(&ollama_base_url)
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let url = build_ollama_url(&ollama_base_url, "/api/version");
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to connect to Ollama: {}", e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("Ollama returned status: {}", response.status()));
+    }
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    Ok(body["version"].as_str().unwrap_or("unknown").to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,9 +10,11 @@
  * - llm: LLM 聊天相关命令 (流式消息、对话管理)
  * - mcp: MCP 服务器相关命令 (工具调用、服务器管理)
  * - constants: 超时和延迟常量
+ * - local_model: 本地模型管理命令 (Ollama 集成)
  */
 
 pub mod auth;
 pub mod constants;
 pub mod llm;
+pub mod local_model;
 pub mod mcp;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -159,6 +159,14 @@ fn main() {
             commands::mcp::get_all_mcp_tools,
             commands::mcp::call_mcp_tool,
             commands::mcp::test_mcp_connection,
+            // Local model commands
+            commands::local_model::check_ollama_status,
+            commands::local_model::list_local_models,
+            commands::local_model::show_local_model,
+            commands::local_model::pull_local_model,
+            commands::local_model::delete_local_model,
+            commands::local_model::get_model_sources_cmd,
+            commands::local_model::get_ollama_version,
             // 日志相关命令
             get_log_path,
             read_log_file,

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -527,7 +527,8 @@ export const useChatStore = defineStore("chat", () => {
     }
 
     // 检查 API 密钥是否已加载
-    if (!config.apiKey) {
+    // Local models don't require API keys
+    if (config.provider !== "local" && !config.apiKey) {
       console.error("API key not loaded for config:", config.id);
       alert("API 密钥未加载，请重启应用或重新设置");
       return;

--- a/src/stores/localModel.ts
+++ b/src/stores/localModel.ts
@@ -1,0 +1,341 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * BaiyuAISpace 本地模型管理模块
+ * 负责管理通过 Ollama 部署的本地模型，包括模型列表、下载、删除等功能
+ */
+
+import { ref, computed } from "vue";
+import { defineStore } from "pinia";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+/**
+ * 本地模型信息
+ * 与后端 LocalModelInfo 结构对应
+ */
+export interface LocalModelInfo {
+  name: string;
+  model: string;
+  modifiedAt: string;
+  size: number;
+  digest: string;
+  details: ModelDetails | null;
+}
+
+/**
+ * 模型详细信息
+ */
+export interface ModelDetails {
+  parentModel: string | null;
+  format: string | null;
+  family: string | null;
+  families: string[] | null;
+  parameterSize: string | null;
+  quantizationLevel: string | null;
+}
+
+/**
+ * 模型下载源
+ */
+export interface ModelSource {
+  id: string;
+  name: string;
+  baseUrl: string;
+  description: string;
+}
+
+/**
+ * 下载进度事件
+ */
+export interface DownloadProgress {
+  modelName: string;
+  status: string;
+  digest: string;
+  total: number | null;
+  completed: number | null;
+}
+
+/**
+ * 本地模型 Store
+ * 使用 Pinia 管理本地模型状态和业务逻辑
+ */
+export const useLocalModelStore = defineStore(
+  "localModel",
+  () => {
+    // ============ 响应式状态 ============
+
+    /** Ollama 服务基础 URL */
+    const ollamaBaseUrl = ref("http://localhost:11434");
+
+    /** Ollama 服务是否在线 */
+    const isOnline = ref(false);
+
+    /** Ollama 版本号 */
+    const ollamaVersion = ref("");
+
+    /** 本地模型列表 */
+    const localModels = ref<LocalModelInfo[]>([]);
+
+    /** 可用的模型下载源列表 */
+    const modelSources = ref<ModelSource[]>([]);
+
+    /** 当前选中的下载源 ID */
+    const selectedSourceId = ref("ollama");
+
+    /** 是否正在加载模型列表 */
+    const isLoadingModels = ref(false);
+
+    /** 是否正在下载模型 */
+    const isPulling = ref(false);
+
+    /** 当前正在下载的模型名称 */
+    const pullingModelName = ref("");
+
+    /** 下载进度信息 */
+    const downloadProgress = ref<DownloadProgress | null>(null);
+
+    /** 下载进度监听器取消函数 */
+    let unlistenDownload: UnlistenFn | null = null;
+
+    // ============ 计算属性 ============
+
+    /** 当前选中的下载源 */
+    const selectedSource = computed(() => {
+      return modelSources.value.find((s) => s.id === selectedSourceId.value) || null;
+    });
+
+    /** 下载进度百分比 */
+    const downloadPercent = computed(() => {
+      if (!downloadProgress.value || !downloadProgress.value.total) return null;
+      const { completed, total } = downloadProgress.value;
+      if (completed == null || total == null) return null;
+      return Math.round((completed / total) * 100);
+    });
+
+    /** 模型列表下拉选项（用于聊天页面选择） */
+    const localModelOptions = computed(() => {
+      return localModels.value.map((m) => ({
+        label: m.name,
+        value: m.name,
+      }));
+    });
+
+    // ============ 方法函数 ============
+
+    /**
+     * 检查 Ollama 服务状态
+     */
+    const checkStatus = async () => {
+      try {
+        isOnline.value = await invoke<boolean>("check_ollama_status", {
+          ollamaBaseUrl: ollamaBaseUrl.value,
+        });
+        if (isOnline.value) {
+          await fetchVersion();
+        }
+      } catch (error) {
+        console.error("Failed to check Ollama status:", error);
+        isOnline.value = false;
+      }
+    };
+
+    /**
+     * 获取 Ollama 版本号
+     */
+    const fetchVersion = async () => {
+      try {
+        ollamaVersion.value = await invoke<string>("get_ollama_version", {
+          ollamaBaseUrl: ollamaBaseUrl.value,
+        });
+      } catch (error) {
+        console.error("Failed to get Ollama version:", error);
+        ollamaVersion.value = "";
+      }
+    };
+
+    /**
+     * 加载本地模型列表
+     */
+    const loadModels = async () => {
+      if (!isOnline.value) {
+        await checkStatus();
+        if (!isOnline.value) return;
+      }
+
+      isLoadingModels.value = true;
+      try {
+        localModels.value = await invoke<LocalModelInfo[]>("list_local_models", {
+          ollamaBaseUrl: ollamaBaseUrl.value,
+        });
+      } catch (error) {
+        console.error("Failed to load local models:", error);
+        localModels.value = [];
+      } finally {
+        isLoadingModels.value = false;
+      }
+    };
+
+    /**
+     * 加载模型下载源列表
+     */
+    const loadModelSources = async () => {
+      try {
+        modelSources.value = await invoke<ModelSource[]>("get_model_sources_cmd");
+      } catch (error) {
+        console.error("Failed to load model sources:", error);
+        modelSources.value = [];
+      }
+    };
+
+    /**
+     * 设置 Ollama 服务地址
+     */
+    const setOllamaBaseUrl = async (url: string) => {
+      ollamaBaseUrl.value = url;
+      await checkStatus();
+      if (isOnline.value) {
+        await loadModels();
+      }
+    };
+
+    /**
+     * 设置默认下载源
+     */
+    const setSelectedSourceId = (sourceId: string) => {
+      selectedSourceId.value = sourceId;
+    };
+
+    /**
+     * 拉取（下载）模型
+     * @param modelName 模型名称
+     * @param sourceId 下载源 ID（可选，使用当前选中的源）
+     */
+    const pullModel = async (modelName: string, sourceId?: string) => {
+      if (isPulling.value) return;
+
+      isPulling.value = true;
+      pullingModelName.value = modelName;
+      downloadProgress.value = null;
+
+      try {
+        await setupDownloadListener();
+
+        await invoke("pull_local_model", {
+          request: {
+            modelName,
+            sourceId: sourceId || selectedSourceId.value,
+            insecure: false,
+          },
+          ollamaBaseUrl: ollamaBaseUrl.value,
+        });
+
+        // Download completed, refresh model list
+        await loadModels();
+      } catch (error) {
+        console.error("Failed to pull model:", error);
+        throw error;
+      } finally {
+        isPulling.value = false;
+        pullingModelName.value = "";
+        downloadProgress.value = null;
+        if (unlistenDownload) {
+          unlistenDownload();
+          unlistenDownload = null;
+        }
+      }
+    };
+
+    /**
+     * 删除本地模型
+     */
+    const deleteModel = async (modelName: string) => {
+      try {
+        await invoke("delete_local_model", {
+          request: { modelName },
+          ollamaBaseUrl: ollamaBaseUrl.value,
+        });
+        // Refresh model list after deletion
+        await loadModels();
+      } catch (error) {
+        console.error("Failed to delete model:", error);
+        throw error;
+      }
+    };
+
+    /**
+     * 设置下载进度监听器
+     */
+    const setupDownloadListener = async () => {
+      if (unlistenDownload) {
+        unlistenDownload();
+      }
+
+      unlistenDownload = await listen<DownloadProgress>(
+        "download-progress",
+        (event) => {
+          downloadProgress.value = event.payload;
+        }
+      );
+    };
+
+    /**
+     * 格式化文件大小
+     */
+    const formatSize = (bytes: number): string => {
+      if (bytes === 0) return "0 B";
+      const units = ["B", "KB", "MB", "GB", "TB"];
+      const i = Math.floor(Math.log(bytes) / Math.log(1024));
+      const size = bytes / Math.pow(1024, i);
+      return `${size.toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
+    };
+
+    /**
+     * 获取模型显示名称（去掉标签后缀）
+     */
+    const getModelDisplayName = (modelName: string): string => {
+      const colonIndex = modelName.indexOf(":");
+      return colonIndex > 0 ? modelName.substring(0, colonIndex) : modelName;
+    };
+
+    // ============ 返回公共接口 ============
+    return {
+      // 状态
+      ollamaBaseUrl,
+      isOnline,
+      ollamaVersion,
+      localModels,
+      modelSources,
+      selectedSourceId,
+      isLoadingModels,
+      isPulling,
+      pullingModelName,
+      downloadProgress,
+
+      // 计算属性
+      selectedSource,
+      downloadPercent,
+      localModelOptions,
+
+      // 方法
+      checkStatus,
+      fetchVersion,
+      loadModels,
+      loadModelSources,
+      setOllamaBaseUrl,
+      setSelectedSourceId,
+      pullModel,
+      deleteModel,
+      formatSize,
+      getModelDisplayName,
+    };
+  },
+  {
+    persist: {
+      key: "baiyu-aispace-local-model",
+      paths: ["ollamaBaseUrl", "selectedSourceId"],
+    },
+  }
+);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -80,6 +80,10 @@ export const PRESET_PROVIDERS: Record<string, { name: string; baseUrl: string }>
     name: "零一万物 (Yi)",
     baseUrl: "https://api.lingyiwanwu.com/v1",
   },
+  local: {
+    name: "本地模型 (Ollama)",
+    baseUrl: "http://localhost:11434/v1",
+  },
   custom: {
     name: "自定义 (OpenAI 兼容)",
     baseUrl: "http://localhost:11434/v1",

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -43,6 +43,9 @@ import {
   NIcon,
   NText,
   NEmpty,
+  NProgress,
+  NAlert,
+  NTooltip,
   useMessage
 } from "naive-ui";
 import { 
@@ -51,6 +54,11 @@ import {
   type ApiConfig,
   type EmbeddingApiConfig
 } from "@/stores/settings";
+import {
+  useLocalModelStore,
+  type LocalModelInfo,
+  type ModelSource
+} from "@/stores/localModel";
 import { 
   ServerOutline, 
   KeyOutline, 
@@ -61,13 +69,22 @@ import {
   CreateOutline,
   CheckmarkCircle,
   LinkOutline,
-  CubeOutline
+  CubeOutline,
+  CloudDownloadOutline,
+  HardwareChipOutline,
+  RefreshOutline,
+  CheckmarkOutline,
+  CloseOutline,
+  AlertCircleOutline,
 } from "@vicons/ionicons5";
 
 // ============ 状态管理 ============
 
 // 设置 Store - 管理 API 配置和主题
 const settings = useSettingsStore();
+
+// 本地模型 Store
+const localModel = useLocalModelStore();
 
 // 消息提示 - 用于操作反馈
 const message = useMessage();
@@ -137,6 +154,31 @@ const embeddingFormData = ref({
   model: "text-embedding-3-small",  // 默认模型
   apiKey: "",                // API 密钥
 });
+
+// ============ 本地模型相关状态 ============
+
+/** 是否显示下载模型弹窗 */
+const showPullModal = ref(false);
+
+/** 下载模型表单数据 */
+const pullFormData = ref({
+  modelName: "",
+  sourceId: "ollama",
+});
+
+/** Ollama 地址编辑状态 */
+const ollamaUrlEditing = ref(false);
+
+/** Ollama 地址编辑值 */
+const ollamaUrlEditValue = ref(localModel.ollamaBaseUrl);
+
+/** 下载源选项 */
+const sourceOptions = computed(() =>
+  localModel.modelSources.map((source: ModelSource) => ({
+    label: source.name,
+    value: source.id,
+  }))
+);
 
 // ============ 表单方法 ============
 
@@ -425,6 +467,73 @@ const handleSetEmbeddingActive = (configId: string) => {
  * 从 Store 获取预设的提供商列表
  */
 const providerOptions = computed(() => settings.presetProviderOptions);
+
+// ============ 本地模型方法 ============
+
+/** 下载模型 */
+const handlePullModel = async () => {
+  if (!pullFormData.value.modelName.trim()) {
+    message.warning("请输入模型名称");
+    return;
+  }
+  try {
+    await localModel.pullModel(pullFormData.value.modelName, pullFormData.value.sourceId);
+    showPullModal.value = false;
+    pullFormData.value.modelName = "";
+    message.success("开始下载模型");
+  } catch (error) {
+    message.error(`下载失败: ${error}`);
+  }
+};
+
+/** 删除本地模型 */
+const handleDeleteModel = async (name: string) => {
+  try {
+    await localModel.deleteModel(name);
+    message.success(`已删除模型: ${name}`);
+  } catch (error) {
+    message.error(`删除失败: ${error}`);
+  }
+};
+
+/** 刷新本地模型列表 */
+const handleRefreshModels = async () => {
+  try {
+    await localModel.refreshModels();
+    message.success("已刷新模型列表");
+  } catch (error) {
+    message.error(`刷新失败: ${error}`);
+  }
+};
+
+/** 创建本地模型 API 配置 */
+const handleCreateLocalConfig = (modelInfo: LocalModelInfo) => {
+  const configName = `local-${modelInfo.name}`;
+  settings.addApiConfig({
+    name: configName,
+    provider: "local",
+    baseUrl: localModel.ollamaBaseUrl.replace(/\/$/, ""),
+    model: modelInfo.name,
+    apiKey: "",
+  });
+  message.success(`已创建配置: ${configName}`);
+};
+
+/** 保存 Ollama 地址 */
+const handleSaveOllamaUrl = () => {
+  localModel.setOllamaBaseUrl(ollamaUrlEditValue.value);
+  ollamaUrlEditing.value = false;
+  message.success("Ollama 地址已更新");
+};
+
+/** 格式化文件大小 */
+const formatSize = (bytes: number): string => {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+};
 </script>
 
 <template>
@@ -733,6 +842,271 @@ const providerOptions = computed(() => settings.presetProviderOptions);
               </n-icon>
               Embedding API 用于知识库的文档向量化和检索查询
             </n-text>
+          </template>
+        </n-card>
+
+        <!-- 本地模型管理卡片 -->
+        <n-card
+          class="settings-card"
+          title="本地模型管理"
+          :bordered="false"
+          :segmented="{ content: true, footer: true }"
+        >
+          <template #header-extra>
+            <n-space align="center">
+              <n-button
+                size="small"
+                @click="handleRefreshModels"
+                :loading="localModel.isLoadingModels"
+              >
+                <template #icon>
+                  <n-icon><RefreshOutline /></n-icon>
+                </template>
+                刷新
+              </n-button>
+              <n-button
+                type="primary"
+                size="small"
+                @click="showPullModal = true"
+                :disabled="!localModel.isOllamaOnline"
+              >
+                <template #icon>
+                  <n-icon><CloudDownloadOutline /></n-icon>
+                </template>
+                下载模型
+              </n-button>
+            </n-space>
+          </template>
+
+          <!-- Ollama 状态区域 -->
+          <div class="ollama-status-section">
+            <n-space
+              align="center"
+              justify="space-between"
+            >
+              <n-space align="center">
+                <n-icon
+                  size="20"
+                  :color="localModel.isOllamaOnline ? '#18a058' : '#d03050'"
+                >
+                  <HardwareChipOutline />
+                </n-icon>
+                <n-text v-if="localModel.isOllamaOnline">
+                  Ollama 在线
+                  <n-tag
+                    v-if="localModel.ollamaVersion"
+                    size="small"
+                    type="success"
+                    style="margin-left: 8px;"
+                  >
+                    v{{ localModel.ollamaVersion }}
+                  </n-tag>
+                </n-text>
+                <n-text
+                  v-else
+                  type="error"
+                >
+                  Ollama 离线
+                </n-text>
+              </n-space>
+              <n-space align="center">
+                <template v-if="ollamaUrlEditing">
+                  <n-input
+                    v-model:value="ollamaUrlEditValue"
+                    size="small"
+                    style="width: 250px;"
+                    placeholder="http://localhost:11434"
+                  />
+                  <n-button
+                    size="small"
+                    type="primary"
+                    @click="handleSaveOllamaUrl"
+                  >
+                    <template #icon>
+                      <n-icon><CheckmarkOutline /></n-icon>
+                    </template>
+                  </n-button>
+                  <n-button
+                    size="small"
+                    @click="ollamaUrlEditing = false"
+                  >
+                    <template #icon>
+                      <n-icon><CloseOutline /></n-icon>
+                    </template>
+                  </n-button>
+                </template>
+                <template v-else>
+                  <n-text
+                    depth="3"
+                    style="font-size: 12px;"
+                  >
+                    {{ localModel.ollamaBaseUrl }}
+                  </n-text>
+                  <n-button
+                    size="tiny"
+                    @click="ollamaUrlEditing = true; ollamaUrlEditValue = localModel.ollamaBaseUrl"
+                  >
+                    编辑
+                  </n-button>
+                </template>
+              </n-space>
+            </n-space>
+          </div>
+
+          <!-- 模型列表 -->
+          <n-empty
+            v-if="!localModel.isLoadingModels && localModel.localModels.length === 0"
+            description="暂无本地模型，点击上方「下载模型」添加"
+            style="margin-top: 12px;"
+          />
+
+          <!-- 加载中 -->
+          <div
+            v-if="localModel.isLoadingModels"
+            style="text-align: center; padding: 20px;"
+          >
+            <n-text depth="3">加载模型列表中...</n-text>
+          </div>
+
+          <!-- 下载进度 -->
+          <n-alert
+            v-if="localModel.isPulling"
+            type="info"
+            style="margin: 12px 0;"
+          >
+            <template #icon>
+              <n-icon><CloudDownloadOutline /></n-icon>
+            </template>
+            正在下载: {{ localModel.pullingModelName }}
+            <n-progress
+              v-if="localModel.pullProgress > 0"
+              type="line"
+              :percentage="localModel.pullProgress"
+              :indicator-placement="'inside'"
+              processing
+              style="margin-top: 8px;"
+            />
+          </n-alert>
+
+          <!-- 模型列表内容 -->
+          <n-list
+            v-if="localModel.localModels.length > 0"
+            bordered
+            style="margin-top: 12px;"
+          >
+            <n-list-item
+              v-for="model in localModel.localModels"
+              :key="model.name"
+            >
+              <n-thing>
+                <template #header>
+                  <n-space align="center">
+                    <n-icon><HardwareChipOutline /></n-icon>
+                    {{ model.name }}
+                  </n-space>
+                </template>
+                <template #description>
+                  <n-space
+                    size="small"
+                    style="margin-top: 4px;"
+                  >
+                    <n-tag
+                      v-if="model.details?.parameterSize"
+                      size="small"
+                      type="info"
+                    >
+                      {{ model.details.parameterSize }}
+                    </n-tag>
+                    <n-tag
+                      v-if="model.details?.quantizationLevel"
+                      size="small"
+                    >
+                      {{ model.details.quantizationLevel }}
+                    </n-tag>
+                    <n-tag
+                      v-if="model.size"
+                      size="small"
+                    >
+                      {{ formatSize(model.size) }}
+                    </n-tag>
+                    <n-tag
+                      v-if="model.details?.format"
+                      size="small"
+                    >
+                      {{ model.details.format }}
+                    </n-tag>
+                    <n-tag
+                      v-if="model.details?.family"
+                      size="small"
+                      type="success"
+                    >
+                      {{ model.details.family }}
+                    </n-tag>
+                  </n-space>
+                </template>
+              </n-thing>
+              <template #suffix>
+                <n-space>
+                  <n-tooltip trigger="hover">
+                    <template #trigger>
+                      <n-button
+                        size="small"
+                        type="primary"
+                        @click="handleCreateLocalConfig(model)"
+                      >
+                        <template #icon>
+                          <n-icon><CheckmarkOutline /></n-icon>
+                        </template>
+                      </n-button>
+                    </template>
+                    创建 API 配置用于聊天
+                  </n-tooltip>
+                  <n-popconfirm @positive-click="handleDeleteModel(model.name)">
+                    <template #trigger>
+                      <n-button
+                        size="small"
+                        type="error"
+                      >
+                        <template #icon>
+                          <n-icon><TrashOutline /></n-icon>
+                        </template>
+                      </n-button>
+                    </template>
+                    确定删除模型 {{ model.name }}？
+                  </n-popconfirm>
+                </n-space>
+              </template>
+            </n-list-item>
+          </n-list>
+
+          <!-- 下载源设置 -->
+          <template #footer>
+            <n-space
+              align="center"
+              justify="space-between"
+            >
+              <n-space align="center">
+                <n-text
+                  depth="3"
+                  style="font-size: 12px;"
+                >
+                  默认下载源:
+                </n-text>
+                <n-select
+                  :value="localModel.selectedSourceId"
+                  :options="sourceOptions"
+                  size="small"
+                  style="width: 180px;"
+                  @update:value="localModel.setSelectedSourceId"
+                />
+              </n-space>
+              <n-text
+                depth="3"
+                style="font-size: 12px;"
+              >
+                {{ localModel.localModels.length }} 个本地模型
+              </n-text>
+            </n-space>
           </template>
         </n-card>
 
@@ -1241,6 +1615,98 @@ const providerOptions = computed(() => settings.presetProviderOptions);
         </n-space>
       </template>
     </n-modal>
+
+    <!-- 下载本地模型弹窗 -->
+    <n-modal
+      v-model:show="showPullModal"
+      title="下载本地模型"
+      preset="card"
+      style="width: 500px"
+      :mask-closable="false"
+    >
+      <n-form
+        label-placement="left"
+        label-width="100px"
+      >
+        <n-form-item
+          label="下载源"
+          required
+        >
+          <n-select
+            v-model:value="pullFormData.sourceId"
+            :options="sourceOptions"
+            placeholder="选择下载源"
+          />
+          <template #feedback>
+            <n-text
+              depth="3"
+              style="font-size: 12px;"
+            >
+              {{ localModel.modelSources.find(s => s.id === pullFormData.sourceId)?.description }}
+            </n-text>
+          </template>
+        </n-form-item>
+
+        <n-form-item
+          label="模型名称"
+          required
+        >
+          <n-input
+            v-model:value="pullFormData.modelName"
+            placeholder="例如：llama3, qwen2, mistral, gemma2..."
+          />
+          <template #feedback>
+            <n-text
+              depth="3"
+              style="font-size: 12px;"
+            >
+              <template v-if="pullFormData.sourceId === 'ollama'">
+                输入 Ollama 模型名称，如 llama3:8b、qwen2:7b。浏览可用模型请访问
+                <n-a
+                  href="https://ollama.com/library"
+                  target="_blank"
+                >
+                  ollama.com/library
+                </n-a>
+              </template>
+              <template v-else-if="pullFormData.sourceId === 'huggingface'">
+                输入 HuggingFace 模型路径，如 user/model-name。浏览可用模型请访问
+                <n-a
+                  href="https://huggingface.co/models"
+                  target="_blank"
+                >
+                  huggingface.co/models
+                </n-a>
+              </template>
+              <template v-else-if="pullFormData.sourceId === 'modelscope'">
+                输入 ModelScope 模型名称。浏览可用模型请访问
+                <n-a
+                  href="https://modelscope.cn/models"
+                  target="_blank"
+                >
+                  modelscope.cn/models
+                </n-a>
+              </template>
+            </n-text>
+          </template>
+        </n-form-item>
+      </n-form>
+
+      <template #footer>
+        <n-space justify="end">
+          <n-button @click="showPullModal = false">
+            取消
+          </n-button>
+          <n-button
+            type="primary"
+            :loading="localModel.isPulling"
+            @click="handlePullModel"
+          >
+            {{ localModel.isPulling ? '下载中...' : '开始下载' }}
+          </n-button>
+        </n-space>
+      </template>
+    </n-modal>
   </n-layout>
 </template>
 
@@ -1292,5 +1758,12 @@ const providerOptions = computed(() => settings.presetProviderOptions);
   .n-button {
     margin-left: auto;
   }
+}
+
+/* Ollama 状态区域 */
+.ollama-status-section {
+  padding: 8px 0;
+  border-bottom: 1px solid var(--n-border-color);
+  margin-bottom: 4px;
 }
 </style>


### PR DESCRIPTION
## 功能概述

新增本地模型管理功能，通过 Ollama API 实现模型的下载、列表、删除等管理操作，支持多个模型下载源切换。

## 后端变更

### 新增文件
- **`src-tauri/src/commands/local_model.rs`** - 本地模型管理模块
  - `check_ollama_status` - 检查 Ollama 服务是否在线
  - `list_local_models` - 获取本地已安装模型列表
  - `show_local_model` - 获取单个模型详细信息
  - `pull_local_model` - 下载模型（流式进度推送）
  - `delete_local_model` - 删除本地模型
  - `get_model_sources_cmd` - 获取可用下载源列表
  - `get_ollama_version` - 获取 Ollama 版本号

### 修改文件
- **`src-tauri/src/commands/llm.rs`** - 新增 `local` provider 支持
  - `PROVIDER_CONFIGS` 新增 `local` 条目
  - `build_url` 处理 `local` provider（使用 base_url 拼接）
  - `build_headers` 对 `local` 跳过认证头
  - `get_api_key` 对 `local` 允许空密钥
- **`src-tauri/src/main.rs`** - 注册 7 个新 Tauri 命令
- **`src-tauri/src/commands/mod.rs`** - 声明 `local_model` 模块

## 前端变更

### 新增文件
- **`src/stores/localModel.ts`** - 本地模型状态管理
  - Ollama 服务状态检测与版本获取
  - 本地模型列表管理（加载、刷新）
  - 多源模型下载（Ollama / HuggingFace / ModelScope）
  - 下载进度实时监听（Tauri 事件系统）
  - Ollama 地址配置持久化

### 修改文件
- **`src/stores/settings.ts`** - `PRESET_PROVIDERS` 新增 `local` provider
- **`src/stores/chat.ts`** - `sendMessage` 对 `local` provider 跳过 API Key 检查
- **`src/views/SettingsView.vue`** - 新增本地模型管理卡片
  - Ollama 服务状态显示与地址配置
  - 本地模型列表（参数量、量化级别、大小、架构）
  - 模型下载弹窗（支持多源切换，含社区链接）
  - 下载进度条实时显示
  - 一键创建 API 配置（直接用于聊天）
  - 默认下载源设置

## 技术要点

- 前后端命令链接严格匹配（Tauri 自动 snake_case ↔ camelCase 转换）
- 使用 Tauri 事件系统 (`emit`/`listen`) 实现下载进度实时推送
- `local` provider 完全免 API Key，兼容 Ollama OpenAI 兼容 API
- 下载源可在设置界面切换，配置持久化到 localStorage
- 编译测试通过（`cargo check` 零错误零警告）

## 使用方式

1. 安装并启动 [Ollama](https://ollama.ai)
2. 进入设置页面 → 本地模型卡片
3. 点击「下载模型」选择下载源和模型名称
4. 下载完成后点击 ✓ 按钮创建 API 配置
5. 在聊天页面选择该配置即可使用本地模型