### PR TITLE
Fix #44: Refactor parse_embedding_response to eliminate code duplication

### DIFF
--- a/src-tauri/src/knowledge_base/embedding.rs
+++ b/src-tauri/src/knowledge_base/embedding.rs
@@ -96,7 +96,6 @@ async fn generate_embeddings_batch(
     );
     
     if provider == "zhipu" {
-        // Zhipu uses Authorization: Bearer token
         headers.insert(
             reqwest::header::AUTHORIZATION,
             format!("Bearer {}", api_key).parse().unwrap(),
@@ -127,55 +126,33 @@ async fn generate_embeddings_batch(
     let json: serde_json::Value = response.json().await
         .map_err(|e| KnowledgeBaseError::EmbeddingError(format!("Failed to parse response: {}", e)))?;
     
-    // Parse embeddings based on provider format
-    let embeddings = parse_embedding_response(&json, provider)?;
+    let embeddings = parse_embedding_response(&json)?;
     
     log::info!("Generated {} embeddings", embeddings.len());
     Ok(embeddings)
 }
 
-/// Parse embedding response
-fn parse_embedding_response(json: &serde_json::Value, provider: &str) -> Result<Vec<Vec<f32>>, KnowledgeBaseError> {
-    match provider {
-        "zhipu" => {
-            // Zhipu format: data[].embedding
-            let data = json.get("data")
-                .and_then(|d| d.as_array())
-                .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Invalid response format".to_string()))?;
-            
-            let mut embeddings = Vec::new();
-            for item in data {
-                let embedding = item.get("embedding")
-                    .and_then(|e| e.as_array())
-                    .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Missing embedding field".to_string()))?;
-                
-                let vec: Vec<f32> = embedding.iter()
-                    .filter_map(|v| v.as_f64().map(|f| f as f32))
-                    .collect();
-                embeddings.push(vec);
-            }
-            Ok(embeddings)
-        }
-        _ => {
-            // OpenAI format: data[].embedding
-            let data = json.get("data")
-                .and_then(|d| d.as_array())
-                .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Invalid response format".to_string()))?;
-            
-            let mut embeddings = Vec::new();
-            for item in data {
-                let embedding = item.get("embedding")
-                    .and_then(|e| e.as_array())
-                    .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Missing embedding field".to_string()))?;
-                
-                let vec: Vec<f32> = embedding.iter()
-                    .filter_map(|v| v.as_f64().map(|f| f as f32))
-                    .collect();
-                embeddings.push(vec);
-            }
-            Ok(embeddings)
-        }
+fn parse_embedding_array(data: &[serde_json::Value]) -> Result<Vec<Vec<f32>>, KnowledgeBaseError> {
+    let mut embeddings = Vec::new();
+    for item in data {
+        let embedding = item.get("embedding")
+            .and_then(|e| e.as_array())
+            .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Missing embedding field".to_string()))?;
+        
+        let vec: Vec<f32> = embedding.iter()
+            .filter_map(|v| v.as_f64().map(|f| f as f32))
+            .collect();
+        embeddings.push(vec);
     }
+    Ok(embeddings)
+}
+
+fn parse_embedding_response(json: &serde_json::Value) -> Result<Vec<Vec<f32>>, KnowledgeBaseError> {
+    let data = json.get("data")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Invalid response format".to_string()))?;
+    
+    parse_embedding_array(data)
 }
 
 /// Generate single embedding


### PR DESCRIPTION
## Fixes
Fixes #44

## 问题摘要
embedding.rs 中 parse_embedding_response 函数 zhipu 分支和默认分支有完全相同的解析逻辑，造成代码重复。

## 根因分析
原代码使用 match 分支处理不同 provider，但两个分支的解析逻辑完全相同，只是注释不同。这违反了 DRY (Dont Repeat Yourself) 原则。

## 修复方案
1. 新增 `parse_embedding_array` 私有函数，提取共同的 embedding 数组解析逻辑
2. 简化 `parse_embedding_response` 函数，移除不再需要的 provider 参数
3. 删除重复的代码分支

## 验证结果
- 代码行数减少：-23 行
- 编译通过
- 功能保持不变

## 影响范围
仅影响 knowledge_base 模块的 embedding 解析逻辑。