### PR TITLE
Fix #45: Rename drop_kb_table to delete_kb_vectors for accuracy

### DIFF
--- a/src-tauri/src/knowledge_base/commands.rs
+++ b/src-tauri/src/knowledge_base/commands.rs
@@ -142,7 +142,7 @@ pub async fn delete_knowledge_base(
     ).map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
     
     // Delete vector table
-    kb_state.vector_store.drop_kb_table(&kb_id).await?;
+    kb_state.vector_store.delete_kb_vectors(&kb_id).await?;
     
     log::info!("Deleted knowledge base: {}", kb_id);
     Ok(())

--- a/src-tauri/src/knowledge_base/db.rs
+++ b/src-tauri/src/knowledge_base/db.rs
@@ -156,8 +156,8 @@ impl VectorStore {
         Ok(())
     }
 
-    /// Drop knowledge base table
-    pub async fn drop_kb_table(&self, kb_id: &str) -> Result<(), KnowledgeBaseError> {
+    /// Delete all vectors for a knowledge base
+    pub async fn delete_kb_vectors(&self, kb_id: &str) -> Result<(), KnowledgeBaseError> {
         let conn = self.get_conn()?;
 
         conn.execute(
@@ -166,7 +166,7 @@ impl VectorStore {
         )
         .map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
 
-        log::info!("Dropped vectors for knowledge base: {}", kb_id);
+        log::info!("Deleted vectors for knowledge base: {}", kb_id);
         Ok(())
     }
 


### PR DESCRIPTION
## Fixes
Fixes #45

## 问题摘要
drop_kb_table 函数名为 DROP TABLE，但实际执行的是 DELETE 操作，命名不准确可能误导维护者。

## 修复方案
重命名函数和相关注释以准确反映其功能：
- 函数名：drop_kb_table -> delete_kb_vectors
- 注释："Drop knowledge base table" -> "Delete all vectors for a knowledge base"
- 日志消息："Dropped" -> "Deleted"
- 同时更新调用点 (commands.rs)

## 验证结果
- 编译通过
- 功能保持不变

## 影响范围
仅影响 knowledge_base 模块的向量删除功能。