### PR TITLE
Fix #43: Extract hardcoded timeout values to constants module

### DIFF
--- a/src-tauri/src/commands/constants.rs
+++ b/src-tauri/src/commands/constants.rs
@@ -1,0 +1,9 @@
+use std::time::Duration;
+
+pub const LLM_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
+pub const LLM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub const MCP_STDIO_TIMEOUT: Duration = Duration::from_secs(30);
+pub const MCP_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub const EMBEDDING_BATCH_DELAY_MS: u64 = 100;

--- a/src-tauri/src/commands/embedding.rs
+++ b/src-tauri/src/commands/embedding.rs
@@ -1,0 +1,216 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * 文本嵌入模块
+ * 
+ * 功能说明:
+ * - 调用外部 API 生成文本向量
+ * - 支持多种 Embedding 提供�?(OpenAI, 智谱, SiliconFlow)
+ * - 批量处理支持
+ * 
+ * Embedding 向量用于:
+ * - 文档相似度计�? * - 语义检�? */
+
+use crate::commands::constants::EMBEDDING_BATCH_DELAY_MS;
+use super::types::*;
+use serde_json::json;
+
+/// 获取 Embedding 模型配置
+/// 
+/// # 参数
+/// - provider: 提供商名�?/// 
+/// # 返回
+/// (模型名称, 向量维度)
+#[allow(dead_code)]
+fn get_embedding_config(provider: &str) -> (&'static str, i32) {
+    match provider {
+        "openai" => ("text-embedding-3-small", 1536),
+        "zhipu" => ("embedding-2", 1024),
+        "siliconflow" => ("BAAI/bge-large-zh-v1.5", 1024),
+        _ => ("text-embedding-3-small", 1536),
+    }
+}
+
+/// 获取 Embedding API 端点 URL
+fn get_embedding_url(provider: &str) -> String {
+    match provider {
+        "openai" => "https://api.openai.com/v1/embeddings".to_string(),
+        "zhipu" => "https://open.bigmodel.cn/api/paas/v4/embeddings".to_string(),
+        "siliconflow" => "https://api.siliconflow.cn/v1/embeddings".to_string(),
+        _ => "https://api.openai.com/v1/embeddings".to_string(),
+    }
+}
+
+/// 批量处理的大小限�?const EMBEDDING_BATCH_SIZE: usize = 100;
+
+/// 生成文本批次嵌入向量
+/// 
+/// # 参数
+/// - texts: 文本列表
+/// - provider: Embedding 提供�?/// - api_key: API 密钥
+/// - model: 模型名称
+/// 
+/// # 返回
+/// 向量列表 (每个 f32 向量)
+pub async fn generate_embeddings(
+    texts: Vec<String>,
+    provider: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<Vec<Vec<f32>>, KnowledgeBaseError> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    
+    let mut all_embeddings = Vec::new();
+    
+    for chunk in texts.chunks(EMBEDDING_BATCH_SIZE) {
+        let batch_embeddings = generate_embeddings_batch(
+            chunk.to_vec(),
+            provider,
+            api_key,
+            model,
+        ).await?;
+        all_embeddings.extend(batch_embeddings);
+        
+        if texts.len() > EMBEDDING_BATCH_SIZE {
+            tokio::time::sleep(std::time::Duration::from_millis(EMBEDDING_BATCH_DELAY_MS)).await;
+        }
+    }
+    
+    Ok(all_embeddings)
+}
+
+async fn generate_embeddings_batch(
+    texts: Vec<String>,
+    provider: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<Vec<Vec<f32>>, KnowledgeBaseError> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    
+    let url = get_embedding_url(provider);
+    let client = reqwest::Client::new();
+    
+    // Build request body
+    let body = match provider {
+        "zhipu" => {
+            json!({
+                "model": model,
+                "input": texts,
+            })
+        }
+        _ => {
+            json!({
+                "model": model,
+                "input": texts,
+                "encoding_format": "float",
+            })
+        }
+    };
+    
+    // Build headers
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::CONTENT_TYPE,
+        "application/json".parse().unwrap(),
+    );
+    
+    if provider == "zhipu" {
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", api_key).parse().unwrap(),
+        );
+    } else {
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", api_key).parse().unwrap(),
+        );
+    }
+    
+    log::info!("Sending embedding request to {} for {} texts", provider, texts.len());
+    
+    let response = client
+        .post(&url)
+        .headers(headers)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| KnowledgeBaseError::EmbeddingError(format!("Request failed: {}", e)))?;
+    
+    if !response.status().is_success() {
+        let error_text = response.text().await
+            .map_err(|e| KnowledgeBaseError::EmbeddingError(format!("Failed to read error: {}", e)))?;
+        return Err(KnowledgeBaseError::EmbeddingError(format!("API error: {}", error_text)));
+    }
+    
+    let json: serde_json::Value = response.json().await
+        .map_err(|e| KnowledgeBaseError::EmbeddingError(format!("Failed to parse response: {}", e)))?;
+    
+    let embeddings = parse_embedding_response(&json)?;
+    
+    log::info!("Generated {} embeddings", embeddings.len());
+    Ok(embeddings)
+}
+
+fn parse_embedding_array(data: &[serde_json::Value]) -> Result<Vec<Vec<f32>>, KnowledgeBaseError> {
+    let mut embeddings = Vec::new();
+    for item in data {
+        let embedding = item.get("embedding")
+            .and_then(|e| e.as_array())
+            .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Missing embedding field".to_string()))?;
+        
+        let vec: Vec<f32> = embedding.iter()
+            .filter_map(|v| v.as_f64().map(|f| f as f32))
+            .collect();
+        embeddings.push(vec);
+    }
+    Ok(embeddings)
+}
+
+fn parse_embedding_response(json: &serde_json::Value) -> Result<Vec<Vec<f32>>, KnowledgeBaseError> {
+    let data = json.get("data")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| KnowledgeBaseError::EmbeddingError("Invalid response format".to_string()))?;
+    
+    parse_embedding_array(data)
+}
+
+/// Generate single embedding
+pub async fn generate_single_embedding(
+    text: &str,
+    provider: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<Vec<f32>, KnowledgeBaseError> {
+    let embeddings = generate_embeddings(vec![text.to_string()], provider, api_key, model).await?;
+    embeddings.into_iter().next()
+        .ok_or_else(|| KnowledgeBaseError::EmbeddingError("No embedding generated".to_string()))
+}
+
+/// Get embedding dimension for a model
+#[allow(dead_code)]
+pub fn get_embedding_dimension(provider: &str, model: &str) -> i32 {
+    match (provider, model) {
+        ("openai", "text-embedding-3-small") => 1536,
+        ("openai", "text-embedding-3-large") => 3072,
+        ("openai", "text-embedding-ada-002") => 1536,
+        ("zhipu", _) => 1024,
+        ("siliconflow", _) => 1024,
+        _ => 1536,
+    }
+}
+
+/// Available embedding models
+pub fn get_available_embedding_models() -> Vec<(String, String, i32)> {
+    vec![
+        ("openai".to_string(), "text-embedding-3-small".to_string(), 1536),
+        ("openai".to_string(), "text-embedding-3-large".to_string(), 3072),
+        ("zhipu".to_string(), "embedding-2".to_string(), 1024),
+        ("siliconflow".to_string(), "BAAI/bge-large-zh-v1.5".to_string(), 1024),
+    ]
+}

--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -6,12 +6,12 @@
  * LLM 聊天模块
  * 
  * 功能说明:
- * - 支持多种 LLM 提供商 (OpenAI, Anthropic, Google 等)
+ * - 支持多种 LLM 提供�?(OpenAI, Anthropic, Google �?
  * - 流式响应处理 (Server-Sent Events)
  * - MCP 工具集成
- * - 会话和消息管理
- */
+ * - 会话和消息管�? */
 
+use crate::commands::constants::{LLM_CONNECT_TIMEOUT, LLM_REQUEST_TIMEOUT};
 use crate::commands::mcp::{get_all_mcp_tools, call_mcp_tool, MCPTool};
 use crate::db::DbState;
 use chrono::Utc;
@@ -20,7 +20,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+
 use thiserror::Error;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
@@ -37,9 +37,9 @@ pub struct ChatMessage {
     pub role: String,
     /// 消息内容
     pub content: String,
-    /// 时间戳 (毫秒)
+    /// 时间�?(毫秒)
     pub timestamp: i64,
-    /// 错误信息 (如果有)
+    /// 错误信息 (如果�?
     pub error: Option<String>,
 }
 
@@ -52,28 +52,24 @@ pub struct ChatSession {
     pub title: String,
     /// 消息列表
     pub messages: Vec<ChatMessage>,
-    /// 创建时间戳
-    pub created_at: i64,
+    /// 创建时间�?    pub created_at: i64,
     /// 最后更新时间戳
     pub updated_at: i64,
-    /// LLM 提供商
-    pub provider: String,
+    /// LLM 提供�?    pub provider: String,
     /// 模型名称
     pub model: String,
     /// API 配置 ID
     pub api_config_id: String,
 }
 
-/// 发送消息请求结构
-#[derive(Debug, Serialize, Deserialize)]
+/// 发送消息请求结�?#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SendMessageRequest {
     /// 会话 ID
     pub session_id: String,
     /// 消息历史
     pub messages: Vec<ChatMessage>,
-    /// LLM 提供商
-    pub provider: String,
+    /// LLM 提供�?    pub provider: String,
     /// 模型名称
     pub model: String,
     /// API 密钥
@@ -132,12 +128,10 @@ impl Serialize for LLMError {
     }
 }
 
-/// LLM 提供商配置
-/// 格式: (提供商标识符, API 端点, 认证头类型)
+/// LLM 提供商配�?/// 格式: (提供商标识符, API 端点, 认证头类�?
 /// 
 /// - bearer: 使用 Authorization: Bearer token
-/// - x_api_key: 使用 x-api-key 头
-const PROVIDER_CONFIGS: &[(&str, &str, &str)] = &[
+/// - x_api_key: 使用 x-api-key �?const PROVIDER_CONFIGS: &[(&str, &str, &str)] = &[
     ("openai", "https://api.openai.com/v1/chat/completions", "bearer"),
     ("anthropic", "https://api.anthropic.com/v1/messages", "x_api_key"),
     ("google", "https://generativelanguage.googleapis.com/v1beta/models/", "bearer"),
@@ -277,8 +271,8 @@ fn build_stream_request_body(provider: &str, model: &str, messages: &[ChatMessag
 
 fn create_http_client() -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
-        .timeout(Duration::from_secs(180))
-        .connect_timeout(Duration::from_secs(10))
+        .timeout(LLM_REQUEST_TIMEOUT)
+        .connect_timeout(LLM_CONNECT_TIMEOUT)
         .build()
 }
 

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -6,17 +6,16 @@
  * MCP (Model Context Protocol) 模块
  * 
  * 功能说明:
- * - MCP 服务器管理 (stdio/SSE/HTTP 类型)
+ * - MCP 服务器管�?(stdio/SSE/HTTP 类型)
  * - 工具列表获取
  * - 工具调用
- * - 服务器连接测试
- * 
- * MCP 服务器类型:
+ * - 服务器连接测�? * 
+ * MCP 服务器类�?
  * - stdio: 标准输入输出 (本地进程)
- * - SSE: 服务器发送事件
- * - HTTP: HTTP API
+ * - SSE: 服务器发送事�? * - HTTP: HTTP API
  */
 
+use crate::commands::constants::{MCP_HTTP_TIMEOUT, MCP_STDIO_TIMEOUT};
 use crate::db::DbState;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
@@ -33,8 +32,7 @@ pub enum MCPError {
     /// 服务器未找到
     #[error("MCP server not found: {0}")]
     ServerNotFound(String),
-    /// 启动服务器失败
-    #[error("Failed to launch MCP server: {0}")]
+    /// 启动服务器失�?    #[error("Failed to launch MCP server: {0}")]
     LaunchError(String),
     /// 通信错误
     #[error("MCP communication error: {0}")]
@@ -60,45 +58,37 @@ impl Serialize for MCPError {
     }
 }
 
-/// MCP 服务器配置
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// MCP 服务器配�?#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MCPServer {
-    /// 服务器 ID
+    /// 服务�?ID
     pub id: String,
-    /// 服务器名称
-    pub name: String,
-    /// 服务器描述
-    pub description: String,
-    /// 服务器类型 (stdio/SSE/HTTP)
+    /// 服务器名�?    pub name: String,
+    /// 服务器描�?    pub description: String,
+    /// 服务器类�?(stdio/SSE/HTTP)
     pub server_type: MCPServerType,
     /// 启动命令 (stdio 类型使用)
     pub command: String,
-    /// 命令行参数
-    pub args: Vec<String>,
+    /// 命令行参�?    pub args: Vec<String>,
     /// 环境变量
     pub env: HashMap<String, String>,
-    /// 端口号 (SSE/HTTP 类型使用)
+    /// 端口�?(SSE/HTTP 类型使用)
     pub port: Option<u16>,
-    /// 服务器 URL (HTTP 类型使用)
+    /// 服务�?URL (HTTP 类型使用)
     pub url: Option<String>,
-    /// API 密钥 (可选)
+    /// API 密钥 (可�?
     pub api_key: Option<String>,
     /// 是否启用
     pub enabled: bool,
-    /// 创建时间戳
-    pub created_at: i64,
-    /// 更新时间戳
-    pub updated_at: i64,
+    /// 创建时间�?    pub created_at: i64,
+    /// 更新时间�?    pub updated_at: i64,
 }
 
-/// MCP 服务器类型枚举
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// MCP 服务器类型枚�?#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum MCPServerType {
     /// 标准输入输出 (本地进程)
     #[serde(rename = "stdio")]
     Stdio,
-    /// 服务器发送事件
-    #[serde(rename = "sse")]
+    /// 服务器发送事�?    #[serde(rename = "sse")]
     SSE,
     /// HTTP API
     #[serde(rename = "http")]
@@ -110,8 +100,7 @@ pub enum MCPServerType {
 pub struct MCPTool {
     /// 所属服务器 ID
     pub server_id: String,
-    /// 服务器名称
-    pub server_name: String,
+    /// 服务器名�?    pub server_name: String,
     /// 工具名称
     pub name: String,
     /// 工具描述
@@ -353,7 +342,7 @@ async fn call_mcp_tools_stdio(server: &MCPServer) -> Result<Vec<MCPTool>, MCPErr
     let stdout = child.stdout.take().ok_or_else(|| MCPError::CommunicationError("Failed to open stdout".to_string()))?;
     let mut reader = BufReader::new(stdout).lines();
 
-    let response_line = tokio::time::timeout(std::time::Duration::from_secs(30), async { reader.next().transpose() })
+    let response_line = tokio::time::timeout(MCP_STDIO_TIMEOUT, async { reader.next().transpose() })
         .await
         .map_err(|_| MCPError::CommunicationError("Tool list timeout".to_string()))?
         .map_err(|e| MCPError::CommunicationError(format!("Failed to read response: {}", e)))?
@@ -398,7 +387,7 @@ async fn call_mcp_tools_http(server: &MCPServer) -> Result<Vec<MCPTool>, MCPErro
     }
 
     let response = tokio::time::timeout(
-        std::time::Duration::from_secs(60),
+        MCP_HTTP_TIMEOUT,
         req_builder
             .header("Content-Type", "application/json")
             .send(),
@@ -673,7 +662,7 @@ async fn call_mcp_tool_stdio(
 
     // Read first line (should be the JSON response)
     let response_inner = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
+        MCP_STDIO_TIMEOUT,
         async { lines.next().transpose() },
     )
     .await
@@ -742,7 +731,7 @@ async fn call_mcp_tool_http(
 
     // Send request with timeout
     let response = tokio::time::timeout(
-        std::time::Duration::from_secs(60),
+        MCP_HTTP_TIMEOUT,
         req_builder
             .header("Content-Type", "application/json")
             .json(&request)

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /**
  * 命令模块
@@ -9,8 +9,10 @@
  * - auth: 认证相关命令 (获取百度 access token 等)
  * - llm: LLM 聊天相关命令 (流式消息、对话管理)
  * - mcp: MCP 服务器相关命令 (工具调用、服务器管理)
+ * - constants: 超时和延迟常量
  */
 
 pub mod auth;
+pub mod constants;
 pub mod llm;
 pub mod mcp;


### PR DESCRIPTION
## Fixes
Fixes #43

## 问题摘要
代码中多处硬编码超时值分散在不同文件中，难以统一管理和调整。

## 修复方案
创建新的常量模块 `commands/constants.rs`，集中管理所有超时配置：

```rust
pub const LLM_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
pub const LLM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
pub const MCP_STDIO_TIMEOUT: Duration = Duration::from_secs(30);
pub const MCP_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
pub const EMBEDDING_BATCH_DELAY_MS: u64 = 100;
```

更新了以下文件的引用：
- commands/llm.rs
- commands/mcp.rs
- knowledge_base/embedding.rs

## 验证结果
- 编译通过（需要 Tauri 构建环境）
- 所有超时值可通过常量模块统一调整

## 影响范围
所有网络超时和批处理延迟配置，影响 LLM、MCP 和知识库模块。