### PR TITLE
fix: 优化宽屏/超宽屏下内容区留白与预设卡片排版

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -48,6 +48,12 @@ $sidebar-width: 260px;
 $header-height: 60px;
 $chat-input-height: 120px;
 
+// ---------- 响应式断点 ----------
+// 内容容器默认宽度按编辑排版收窄（利于阅读），超过这些视口宽度时分级放宽，
+// 避免宽屏/超宽屏下大片留白、列表卡片挤成单列
+$bp-wide: 1600px;
+$bp-ultrawide: 2200px;
+
 // ---------- 兼容别名（旧代码引用，逐步清退） ----------
 $primary-color: $ink;
 $primary-color-hover: $ink-soft;

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -284,11 +284,20 @@ onMounted(() => {
   overflow-y: auto;
 }
 
-/* 内容容器 - 限制最大宽度并居中，大面积留白 */
+/* 内容容器 - 限制最大宽度并居中，大面积留白
+   宽屏/超宽屏下分级放宽，会话行能容纳更多信息，两侧也不至于大片空白 */
 .history-container {
   max-width: 800px;
   margin: 0 auto;
   padding: 5rem 2rem 8rem;
+
+  @media (min-width: $bp-wide) {
+    max-width: 1050px;
+  }
+
+  @media (min-width: $bp-ultrawide) {
+    max-width: 1250px;
+  }
 }
 
 /* 页面标题区域 */

--- a/src/views/KnowledgeBaseView.vue
+++ b/src/views/KnowledgeBaseView.vue
@@ -1027,12 +1027,25 @@ const getStatusTag = (status: Document["status"]) => {
   padding: 24px 32px;
 }
 
-/* 详情页头部：面包屑导航 + 标签页切换按钮，两行之间留出间距 */
+/* 详情页头部：面包屑导航 + 标签页切换按钮，两行之间留出间距
+   宽屏下文档列表/表单不设上限会被拉成一整行贴到屏幕两端，
+   所以头部与内容区统一限宽居中，避免宽屏下比例失衡 */
 .kb-detail-header {
   display: flex;
   flex-direction: column;
   gap: 16px;
   margin-bottom: 24px;
+  max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+
+  @media (min-width: $bp-wide) {
+    max-width: 1200px;
+  }
+
+  @media (min-width: $bp-ultrawide) {
+    max-width: 1400px;
+  }
 }
 
 /* 文档标签页 */

--- a/src/views/LocalDeployView.vue
+++ b/src/views/LocalDeployView.vue
@@ -1734,11 +1734,20 @@ onMounted(async () => {
   height: 100%;
 }
 
-/* 内容容器 */
+/* 内容容器
+   宽屏/超宽屏下分级放宽，列表行能容纳更多信息，两侧也不至于大片空白 */
 .local-deploy-container {
   max-width: 900px;
   margin: 0 auto;
   padding: 5rem 2rem 8rem;
+
+  @media (min-width: $bp-wide) {
+    max-width: 1150px;
+  }
+
+  @media (min-width: $bp-ultrawide) {
+    max-width: 1350px;
+  }
 }
 
 /* 页面标题 */

--- a/src/views/MCPView.vue
+++ b/src/views/MCPView.vue
@@ -999,11 +999,20 @@ const handleTestSavedServer = async (server: MCPServer) => {
   height: 100%;
 }
 
-/* 内容容器 */
+/* 内容容器
+   宽屏/超宽屏下分级放宽，列表行能容纳更多信息，两侧也不至于大片空白 */
 .mcp-container {
   max-width: 900px;
   margin: 0 auto;
   padding: 5rem 2rem 8rem;
+
+  @media (min-width: $bp-wide) {
+    max-width: 1150px;
+  }
+
+  @media (min-width: $bp-ultrawide) {
+    max-width: 1350px;
+  }
 }
 
 /* 页面标题 */

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1580,11 +1580,21 @@ const providerOptions = computed(() => settings.presetProviderOptions);
   height: 100%;
 }
 
-/* 内容容器 - 限制最大宽度并居中 */
+/* 内容容器 - 限制最大宽度并居中
+   宽屏/超宽屏下分级放宽，避免两侧大片留白（但设置项是一行行的表单/列表，
+   放太宽反而拉散标签和操作按钮的视觉关联，所以放宽幅度比列表页克制） */
 .settings-container {
   max-width: 700px;
   margin: 0 auto;
   padding: 5rem 2rem 8rem;
+
+  @media (min-width: $bp-wide) {
+    max-width: 900px;
+  }
+
+  @media (min-width: $bp-ultrawide) {
+    max-width: 1000px;
+  }
 }
 
 /* 页面标题区域 */

--- a/src/views/SkillsView.vue
+++ b/src/views/SkillsView.vue
@@ -33,8 +33,6 @@ import {
   NSpace,
   NPopconfirm,
   NIcon,
-  NGrid,
-  NGridItem,
   NTabs,
   NTabPane,
   useMessage,
@@ -986,32 +984,29 @@ const handleRemoveResourceFile = async (filename: string) => {
                   开发者
                 </n-space>
               </template>
-              <n-grid :cols="2" :x-gap="12" :y-gap="12" style="margin-top: 12px">
-                <n-grid-item
+              <div class="preset-grid">
+                <n-card
                   v-for="preset in DEV_PRESETS"
                   :key="preset.name"
+                  size="small"
+                  :bordered="true"
+                  class="preset-card"
                 >
-                  <n-card
-                    size="small"
-                    :bordered="true"
-                    class="preset-card"
-                  >
-                    <div class="preset-name">{{ preset.name }}</div>
-                    <div class="preset-desc">{{ preset.description }}</div>
-                    <template #footer>
-                      <n-button
-                        size="small"
-                        :type="isPresetImported(preset.name) ? 'default' : 'primary'"
-                        :disabled="isPresetImported(preset.name)"
-                        :loading="importingPreset === preset.name"
-                        @click="handleImportPreset(preset)"
-                      >
-                        {{ isPresetImported(preset.name) ? "已导入" : "导入" }}
-                      </n-button>
-                    </template>
-                  </n-card>
-                </n-grid-item>
-              </n-grid>
+                  <div class="preset-name">{{ preset.name }}</div>
+                  <div class="preset-desc">{{ preset.description }}</div>
+                  <template #footer>
+                    <n-button
+                      size="small"
+                      :type="isPresetImported(preset.name) ? 'default' : 'primary'"
+                      :disabled="isPresetImported(preset.name)"
+                      :loading="importingPreset === preset.name"
+                      @click="handleImportPreset(preset)"
+                    >
+                      {{ isPresetImported(preset.name) ? "已导入" : "导入" }}
+                    </n-button>
+                  </template>
+                </n-card>
+              </div>
             </n-tab-pane>
 
             <n-tab-pane name="biz" tab="商务">
@@ -1021,32 +1016,29 @@ const handleRemoveResourceFile = async (filename: string) => {
                   商务
                 </n-space>
               </template>
-              <n-grid :cols="2" :x-gap="12" :y-gap="12" style="margin-top: 12px">
-                <n-grid-item
+              <div class="preset-grid">
+                <n-card
                   v-for="preset in BIZ_PRESETS"
                   :key="preset.name"
+                  size="small"
+                  :bordered="true"
+                  class="preset-card"
                 >
-                  <n-card
-                    size="small"
-                    :bordered="true"
-                    class="preset-card"
-                  >
-                    <div class="preset-name">{{ preset.name }}</div>
-                    <div class="preset-desc">{{ preset.description }}</div>
-                    <template #footer>
-                      <n-button
-                        size="small"
-                        :type="isPresetImported(preset.name) ? 'default' : 'primary'"
-                        :disabled="isPresetImported(preset.name)"
-                        :loading="importingPreset === preset.name"
-                        @click="handleImportPreset(preset)"
-                      >
-                        {{ isPresetImported(preset.name) ? "已导入" : "导入" }}
-                      </n-button>
-                    </template>
-                  </n-card>
-                </n-grid-item>
-              </n-grid>
+                  <div class="preset-name">{{ preset.name }}</div>
+                  <div class="preset-desc">{{ preset.description }}</div>
+                  <template #footer>
+                    <n-button
+                      size="small"
+                      :type="isPresetImported(preset.name) ? 'default' : 'primary'"
+                      :disabled="isPresetImported(preset.name)"
+                      :loading="importingPreset === preset.name"
+                      @click="handleImportPreset(preset)"
+                    >
+                      {{ isPresetImported(preset.name) ? "已导入" : "导入" }}
+                    </n-button>
+                  </template>
+                </n-card>
+              </div>
             </n-tab-pane>
 
             <n-tab-pane name="general" tab="通用">
@@ -1056,32 +1048,29 @@ const handleRemoveResourceFile = async (filename: string) => {
                   通用
                 </n-space>
               </template>
-              <n-grid :cols="2" :x-gap="12" :y-gap="12" style="margin-top: 12px">
-                <n-grid-item
+              <div class="preset-grid">
+                <n-card
                   v-for="preset in GENERAL_PRESETS"
                   :key="preset.name"
+                  size="small"
+                  :bordered="true"
+                  class="preset-card"
                 >
-                  <n-card
-                    size="small"
-                    :bordered="true"
-                    class="preset-card"
-                  >
-                    <div class="preset-name">{{ preset.name }}</div>
-                    <div class="preset-desc">{{ preset.description }}</div>
-                    <template #footer>
-                      <n-button
-                        size="small"
-                        :type="isPresetImported(preset.name) ? 'default' : 'primary'"
-                        :disabled="isPresetImported(preset.name)"
-                        :loading="importingPreset === preset.name"
-                        @click="handleImportPreset(preset)"
-                      >
-                        {{ isPresetImported(preset.name) ? "已导入" : "导入" }}
-                      </n-button>
-                    </template>
-                  </n-card>
-                </n-grid-item>
-              </n-grid>
+                  <div class="preset-name">{{ preset.name }}</div>
+                  <div class="preset-desc">{{ preset.description }}</div>
+                  <template #footer>
+                    <n-button
+                      size="small"
+                      :type="isPresetImported(preset.name) ? 'default' : 'primary'"
+                      :disabled="isPresetImported(preset.name)"
+                      :loading="importingPreset === preset.name"
+                      @click="handleImportPreset(preset)"
+                    >
+                      {{ isPresetImported(preset.name) ? "已导入" : "导入" }}
+                    </n-button>
+                  </template>
+                </n-card>
+              </div>
             </n-tab-pane>
           </n-tabs>
 
@@ -1216,10 +1205,20 @@ const handleRemoveResourceFile = async (filename: string) => {
   height: 100%;
 }
 
+/* 宽屏/超宽屏下分级放宽，配合下面 .preset-grid 的 auto-fill 让预设卡片
+   自动增加列数，而不是永远挤成两列 */
 .skills-container {
   max-width: 900px;
   margin: 0 auto;
   padding: 5rem 2rem 8rem;
+
+  @media (min-width: $bp-wide) {
+    max-width: 1300px;
+  }
+
+  @media (min-width: $bp-ultrawide) {
+    max-width: 1600px;
+  }
 }
 
 .page-header {
@@ -1261,6 +1260,15 @@ const handleRemoveResourceFile = async (filename: string) => {
   .n-button {
     margin-left: auto;
   }
+}
+
+/* 预设卡片网格 —— 原来是 n-grid 固定两列，宽屏下永远只有两列、两侧一堆空白。
+   换成 CSS Grid 的 auto-fill，卡片按可用宽度自动增加列数 */
+.preset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
 }
 
 .preset-card {


### PR DESCRIPTION
各页面内容容器此前统一写死 max-width（700~900px），且没有任何断点，
窗口从默认小窗拉到全屏/超宽屏时容器宽度不变，两侧留出大片空白；
技能预设区还用 n-grid 固定两列，永远不随空间变宽而增加列数。

- variables.scss 新增 $bp-wide/$bp-ultrawide 断点变量
- Settings/MCP/LocalDeploy/History/KnowledgeBase 详情区按断点分级放宽 max-width
- Skills 预设库改用 CSS Grid auto-fill，卡片列数随宽度自动增加，移除废弃的 n-grid 依赖