### PR TITLE
feat: MCP 推荐服务新增网络搜索预设

### DIFF
--- a/src/views/MCPView.vue
+++ b/src/views/MCPView.vue
@@ -87,6 +87,14 @@ interface MCPPreset {
 
 const MCP_PRESETS: MCPPreset[] = [
   {
+    id: "web-search",
+    name: "网络搜索",
+    description: "通过 DuckDuckGo 搜索网页并抓取正文内容，让模型获取实时信息，无需 API Key（基于 duckduckgo-mcp-server）",
+    serverType: "stdio",
+    command: "uvx",
+    args: ["duckduckgo-mcp-server"],
+  },
+  {
     id: "filesystem",
     name: "文件系统访问",
     description: "读写指定目录下的本地文件",


### PR DESCRIPTION
## 概述
- MCP 页面的"推荐服务"预设列表里一直缺网络搜索能力,本 PR 补上。
- 新增预设基于 [duckduckgo-mcp-server](https://github.com/nickclyde/duckduckgo-mcp-server)（`uvx duckduckgo-mcp-server`），无需 API Key，开箱即用，暴露 `search`（网页搜索）和 `fetch_content`（抓取正文）两个工具。
- 做法与现有 filesystem / git / time 等预设完全一致：只是往 `MCP_PRESETS` 数组里加一条，点击后预填"添加服务"表单，实际由用户确认后创建，首次调用时通过 `uvx` 自动拉取真实的社区 MCP 包运行。

## 测试计划
- [x] `pnpm build`（vue-tsc + vite build）通过
- [x] `cargo build`（src-tauri debug 编译）通过
- [ ] 人工验证：MCP 页面能看到"网络搜索"预设卡片，点击"使用此配置"后表单正确预填，保存后可正常调用 `search`/`fetch_content` 工具（需要本机装有 `uv`/`uvx`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)