### PR TITLE
feat: 新增全局 System Prompt 配置项

### DIFF
--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -672,6 +672,27 @@ export const useChatStore = defineStore("chat", () => {
           };
         });
 
+      // ============ 全局 System Prompt ============
+      const globalSystemPrompt = settings.systemPrompt.trim();
+      if (globalSystemPrompt) {
+        if (apiMessages.length > 0 && apiMessages[0].role === "system") {
+          apiMessages[0] = {
+            ...apiMessages[0],
+            content: globalSystemPrompt + "\n\n" + apiMessages[0].content,
+          };
+        } else {
+          apiMessages.unshift({
+            id: crypto.randomUUID(),
+            role: "system",
+            content: globalSystemPrompt,
+            timestamp: Date.now(),
+            error: undefined,
+            images: [],
+            videos: [],
+          });
+        }
+      }
+
       // ============ MCP 系统提示 ============
       if (mcpEnabled.value && mcp.availableTools.length > 0) {
         const mcpSystemPrompt = buildMcpSystemPrompt(mcp.availableTools);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -220,6 +220,9 @@ export const useSettingsStore = defineStore(
       }
     };
 
+    // 全局默认 System Prompt，发送每次对话请求时会自动附加到系统消息中
+    const systemPrompt = ref("");
+
     // ============ API 配置状态 ============
     
     // LLM API 配置列表 (支持多配置)
@@ -563,6 +566,7 @@ export const useSettingsStore = defineStore(
       showHotkey,
       setShowHotkey,
       syncShowHotkey,
+      systemPrompt,
       apiConfigs,
       activeConfigId,
       activeConfig,
@@ -598,7 +602,7 @@ export const useSettingsStore = defineStore(
   {
     persist: {
       key: "baiyu-aispace-settings",
-      paths: ["darkMode", "closeToTray", "showHotkey", "apiConfigs", "activeConfigId", "embeddingApiConfigs", "activeEmbeddingApiConfigId", "rerankerApiConfigs"],
+      paths: ["darkMode", "closeToTray", "showHotkey", "systemPrompt", "apiConfigs", "activeConfigId", "embeddingApiConfigs", "activeEmbeddingApiConfigId", "rerankerApiConfigs"],
       // apiKey lives in secure storage (see saveApiKeyToSecureStorage) and is
       // only kept in these arrays in-memory for request building. Without
       // this serializer it would otherwise round-trip into plaintext

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1014,6 +1014,24 @@ const providerOptions = computed(() => settings.presetProviderOptions);
               </n-button>
             </n-space>
           </div>
+
+          <div class="general-setting-item general-setting-item--stack">
+            <div class="general-setting-text">
+              <span class="general-setting-label">全局 System Prompt</span>
+              <n-text
+                depth="3"
+                style="font-size: 12px;"
+              >
+                对之后发送的每条新消息生效，会自动附加到对话的系统消息中，用于统一设定模型的身份、语气或回答规范；留空则不附加。已发送的历史消息不受影响。
+              </n-text>
+            </div>
+            <n-input
+              v-model:value="settings.systemPrompt"
+              type="textarea"
+              placeholder="例如：你是一个简洁、专业的助手，优先给出可执行的建议，避免空泛的客套话。"
+              :autosize="{ minRows: 3, maxRows: 8 }"
+            />
+          </div>
         </n-card>
 
         <!-- 关于卡片 -->
@@ -1653,6 +1671,11 @@ const providerOptions = computed(() => settings.presetProviderOptions);
   margin-top: 20px;
   padding-top: 20px;
   border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.general-setting-item--stack {
+  flex-direction: column;
+  align-items: stretch;
 }
 
 .general-setting-text {


### PR DESCRIPTION
## 概述

- 在设置页「通用设置」卡片新增「全局 System Prompt」文本域，支持配置一段对之后所有新消息生效的系统提示词。
- 发送消息前，若该配置非空，会自动合并进对话的系统消息：已有系统消息（历史消息或后续的 MCP 提示）则前置拼接，没有则插入一条新的，顺序与现有 MCP/Skill 系统提示的合并约定保持一致。
- 纯前端改动，未涉及 Rust 后端。

## 改动文件

- `src/stores/settings.ts`：新增 `systemPrompt` 状态字段，纳入 persistedstate 持久化。
- `src/views/SettingsView.vue`：新增文本域 UI（中文说明 + placeholder，符合黑白编辑设计系统）。
- `src/stores/chat.ts`：`sendMessage` 中在 MCP 系统提示注入之前，合并全局 System Prompt 到 `apiMessages[0]`。

## 测试

- [x] `pnpm build`（vue-tsc + vite build）通过
- [x] `pnpm tauri build` 全量编译 + NSIS 打包通过
- [x] 用 `run-baiyuaispace2` driver 实测：Settings 页正确展示新文本域，输入内容后正确持久化到 `baiyu-aispace-settings`（Pinia persistedstate），测试完已清空复原

🤖 Generated with [Claude Code](https://claude.com/claude-code)