### PR TITLE
feat: Release CD 为 Windows 额外打包便携版单文件 exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 # CD：推送 v* 标签时，自动在三个平台打安装包并创建 GitHub Release（草稿）
+# Windows 额外附带一份便携版单文件 exe（未打包的原始二进制，免安装双击运行）
 # 用法：git tag v0.1.0 && git push origin v0.1.0
 # 打完后到 GitHub Releases 页面检查草稿，确认没问题再手动发布
 name: Release
@@ -64,7 +65,18 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'BaiyuAISpace ${{ github.ref_name }}'
-          releaseBody: '各平台安装包见下方 Assets。Windows 用 .exe（NSIS），macOS 用 .dmg，Linux 用 .AppImage。'
+          releaseBody: '各平台安装包见下方 Assets。Windows 提供 .exe 安装包（NSIS）和便携版单文件 exe（免安装，双击运行），macOS 用 .dmg，Linux 用 .AppImage。'
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+
+      # tauri-action 打包前会先编译出未打包的原始二进制（前端资源已编译期嵌入，
+      # 单文件即可运行，仅依赖系统自带的 WebView2 Runtime）；这里改名后追加上传到同一个 Release
+      - name: Upload portable exe (Windows only)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Copy-Item "src-tauri/target/release/BaiyuAISpace2.exe" "BaiyuAISpace-${{ github.ref_name }}-portable.exe"
+          gh release upload ${{ github.ref_name }} "BaiyuAISpace-${{ github.ref_name }}-portable.exe" --clobber


### PR DESCRIPTION
## 改动

`.github/workflows/release.yml` 里 Windows 打包步骤现在会额外产出一份便携版单文件 exe。

Tauri 2 的 NSIS 打包器没有原生的"便携版"打包目标（`installMode` 只控制装给当前用户还是所有用户）。改用 `tauri-action` 打包前就已经编译出来的原始二进制 `src-tauri/target/release/BaiyuAISpace2.exe`——前端资源在编译期已嵌入二进制，单文件即可独立运行，唯一外部依赖是系统自带的 WebView2 Runtime。这里把它改名为 `BaiyuAISpace-<tag>-portable.exe`，用 `gh release upload --clobber` 追加到 tauri-action 已创建的同一个 Release（草稿）里。

同时更新了 releaseBody 文案，标注 Windows 现在有安装包（NSIS）和便携版两种下载。

## 测试计划

- [ ] YAML 语法已人工检查（本机无 js-yaml/pyyaml 可用做自动校验）
- [ ] 打一个测试 tag（如 `v0.1.0-test`）触发 Release workflow，确认 Windows 产物里同时出现 NSIS 安装包和便携版 exe，且便携版可双击直接运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)