### PR TITLE
fix: 重复启动时唤醒已有窗口而非新开进程

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-winres = "0.3"
 
 [dependencies]
 tauri = { version = "2.11", features = ["tray-icon"] }
+tauri-plugin-single-instance = "2"
 tauri-plugin-shell = "2.2"
 tauri-plugin-dialog = "2.7"
 tauri-plugin-global-shortcut = "2.2"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -141,6 +141,14 @@ fn main() {
 
     // 构建 Tauri 应用
     tauri::Builder::default()
+        // 单实例插件：必须最先注册。重复启动时不新开进程，而是唤醒已运行窗口
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }))
         // 注册 Shell 插件 (用于打开外部链接)
         .plugin(tauri_plugin_shell::init())
         // 注册对话框插件 (用于文件选择)


### PR DESCRIPTION
## Summary
- 引入 `tauri-plugin-single-instance`（作为第一个注册的插件），检测到重复启动时不再新开进程
- 回调里将已运行的主窗口 show / unminimize / set_focus，行为与托盘"显示主界面"一致

## 问题背景
应用已启动时，桌面再次点击快捷方式会新开一个进程，导致同时存在多个 BaiyuAISpace 进程。

## Test plan
- [x] `cargo build` 通过
- [x] `pnpm tauri build` 编译并打包成功（release exe + NSIS installer 均生成；末尾更新签名步骤因本地缺少 `TAURI_SIGNING_PRIVATE_KEY` 报错，与本次改动无关，仅 CI 环境才配置该密钥）
- [ ] 用户手动验证：应用运行时重复点击快捷方式，确认只唤起已有窗口、不新开进程

🤖 Generated with [Claude Code](https://claude.com/claude-code)