### PR TITLE
chore: 版本升至 0.2.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.3"
+version = "0.2.0-beta.4"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
版本号从 0.2.0-beta.3 升至 0.2.0-beta.4，为发布新 tag 做准备（包含单实例修复 #65）。

`pnpm build` + `cargo build` 已验证通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)