### PR TITLE
fix: 降低本地部署模型（Ollama/LM Studio）调用的 TTFT

### DIFF
--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -620,21 +620,39 @@ fn append_skill_tools(body: &mut serde_json::Value, provider: &str, autonomous_s
     }
 }
 
-fn create_http_client() -> reqwest::Result<reqwest::Client> {
-    reqwest::Client::builder()
+/// 目标是否回环地址 (localhost/127.0.0.1/::1) —— 本地部署的模型服务
+/// (Ollama/LM Studio 等经由 "local"/"custom"/"openclaw" provider 走到这里)
+/// 走这条路径时应绕开系统代理，否则用户为访问境外服务商而开启的全局代理
+/// 会把本该直连本机的请求也绕出去一圈，白白拖慢 TTFT。
+fn is_loopback_url(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_string()))
+        .map(|host| host == "localhost" || host == "127.0.0.1" || host == "::1" || host.starts_with("127."))
+        .unwrap_or(false)
+}
+
+fn create_http_client(url: &str) -> reqwest::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
         .timeout(LLM_REQUEST_TIMEOUT)
-        .connect_timeout(LLM_CONNECT_TIMEOUT)
-        .build()
+        .connect_timeout(LLM_CONNECT_TIMEOUT);
+    if is_loopback_url(url) {
+        builder = builder.no_proxy();
+    }
+    builder.build()
 }
 
 /// 流式请求专用：`timeout()` 是含读完整个响应体的总时长，SSE 长回复会被
 /// 中途掐断（表现为 "Stream error: error decoding response body"），
 /// 因此这里只设读间隔超时，流只要还在吐数据就不会被断开。
-fn create_streaming_http_client() -> reqwest::Result<reqwest::Client> {
-    reqwest::Client::builder()
+fn create_streaming_http_client(url: &str) -> reqwest::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
         .read_timeout(LLM_STREAM_READ_TIMEOUT)
-        .connect_timeout(LLM_CONNECT_TIMEOUT)
-        .build()
+        .connect_timeout(LLM_CONNECT_TIMEOUT);
+    if is_loopback_url(url) {
+        builder = builder.no_proxy();
+    }
+    builder.build()
 }
 
 fn build_headers(provider: &str, api_key: &str) -> reqwest::header::HeaderMap {
@@ -1004,7 +1022,7 @@ pub async fn stream_message(
         return Err(LLMError::ApiError("Invalid target URL".to_string()));
     }
 
-    let client = create_streaming_http_client()?;
+    let client = create_streaming_http_client(&url)?;
     let mut body = build_stream_request_body(&request.provider, &request.model, &effective_messages, &mcp_tools, request.enable_thinking, request.max_tokens);
     append_skill_tools(&mut body, &request.provider, &autonomous_skills);
     let headers = build_headers(&request.provider, &api_key);
@@ -1322,7 +1340,7 @@ async fn continue_after_tool_calls(
     max_tokens: Option<u32>,
 ) -> Result<ContinuationResult, LLMError> {
     let url = build_url(provider, base_url, model, false);
-    let client = create_http_client()?;
+    let client = create_http_client(&url)?;
 
     // Same empty-message guard as `build_stream_request_body`: a message left
     // contentless by a stream cancelled before any token arrived must not be
@@ -1829,7 +1847,7 @@ pub async fn run_turn(
     tools: &[MCPTool],
 ) -> Result<TurnOutcome, LLMError> {
     let url = build_url(provider, base_url, model, false);
-    let client = create_http_client()?;
+    let client = create_http_client(&url)?;
 
     let body = match provider {
         "anthropic" => {

--- a/src-tauri/src/commands/lmstudio.rs
+++ b/src-tauri/src/commands/lmstudio.rs
@@ -71,6 +71,11 @@ fn create_lmstudio_client() -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(300))
         .connect_timeout(Duration::from_secs(10))
+        // This client only ever talks to the user's own already-running LM
+        // Studio server, never a remote host -- routing it through a system
+        // proxy (as reqwest does by default) can add seconds of detour when
+        // the user has a global-mode proxy running for other providers.
+        .no_proxy()
         .build()
 }
 

--- a/src-tauri/src/commands/local_model.rs
+++ b/src-tauri/src/commands/local_model.rs
@@ -171,20 +171,26 @@ pub fn get_model_sources() -> Vec<ModelSource> {
 
 // ============ Helper functions ============
 
-/// Create HTTP client for Ollama API calls
+/// Create HTTP client for Ollama API calls. This always targets the user's
+/// own Ollama server (local or LAN), never a remote SaaS endpoint, so it's
+/// exempted from the system proxy -- otherwise a global-mode proxy set up
+/// for reaching overseas providers would also detour this local traffic.
 fn create_ollama_client(_base_url: &str) -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(300))
         .connect_timeout(Duration::from_secs(10))
+        .no_proxy()
         .build()
 }
 
 /// 流式下载专用（模型拉取等）：总超时会在下载超过设定时长时把还在
-/// 正常传输的连接掐断，因此只设读间隔超时——断流才算失败。
+/// 正常传输的连接掐断，因此只设读间隔超时——断流才算失败。同样只连
+/// 本地 Ollama 的 /api/pull，绕开系统代理。
 fn create_download_client() -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
         .read_timeout(crate::commands::constants::DOWNLOAD_READ_TIMEOUT)
         .connect_timeout(Duration::from_secs(10))
+        .no_proxy()
         .build()
 }
 
@@ -675,6 +681,7 @@ pub async fn start_ollama_service(
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .connect_timeout(Duration::from_secs(3))
+        .no_proxy()
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 
@@ -718,6 +725,7 @@ pub async fn start_ollama_service(
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .connect_timeout(Duration::from_secs(3))
+        .no_proxy()
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 
@@ -796,6 +804,7 @@ pub async fn get_ollama_service_status(
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
         .connect_timeout(Duration::from_secs(3))
+        .no_proxy()
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -19,15 +19,32 @@
 
 use crate::commands::constants::{MCP_HTTP_TIMEOUT, MCP_STDIO_TIMEOUT, MCP_TOOL_CALL_TIMEOUT};
 use crate::db::DbState;
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::process::Command;
+use tokio::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+
+/// `stream_message` calls `get_all_mcp_tools` on every single chat turn
+/// (needed even when MCP is off, since a manually-activated Skill can still
+/// bind a server) -- without a cache that means re-running `tools/list`
+/// against every enabled server before the LLM request can even be sent.
+/// For stdio servers that's a fresh child process (e.g. `npx ...`) spawned
+/// and torn down per message, which can cost anywhere from hundreds of ms to
+/// the full `MCP_STDIO_TIMEOUT`/`MCP_HTTP_TIMEOUT` ceiling if the server is
+/// slow to start or briefly unreachable -- directly inflating TTFT. Cache
+/// successful lookups for a short TTL; failures are never cached so a
+/// misbehaving server keeps surfacing instead of silently vanishing.
+static MCP_TOOLS_CACHE: Lazy<Mutex<HashMap<String, (Vec<MCPTool>, Instant)>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+const MCP_TOOLS_CACHE_TTL: Duration = Duration::from_secs(300);
 
 /// MCP 错误类型
 #[derive(Error, Debug)]
@@ -213,6 +230,11 @@ pub async fn create_mcp_server(
     let db = state.0.lock().await;
     db.save_mcp_server(&config)
         .map_err(|e| MCPError::CommunicationError(e.to_string()))?;
+    drop(db);
+
+    // The server's command/args/url may have just changed -- drop any cached
+    // tool list so the next lookup re-discovers instead of serving stale data.
+    MCP_TOOLS_CACHE.lock().await.remove(&config.id);
 
     log::info!(
         "MCP server configured: {} (type: {}) [ID: {}]",
@@ -248,6 +270,8 @@ pub async fn delete_mcp_server(
     let db = state.0.lock().await;
     db.delete_mcp_server(&server_id)
         .map_err(|e| MCPError::CommunicationError(e.to_string()))?;
+    drop(db);
+    MCP_TOOLS_CACHE.lock().await.remove(&server_id);
     log::info!("MCP server deleted: {}", server_id);
     Ok(())
 }
@@ -533,10 +557,7 @@ pub async fn get_mcp_tools(
 pub async fn get_all_mcp_tools(state: tauri::State<'_, DbState>) -> Result<Vec<MCPTool>, MCPError> {
     log::info!("Fetching all available MCP tools");
 
-    // Scoped so the DB lock is released before the loop below calls
-    // get_mcp_tools, which re-locks the same (non-reentrant) tokio Mutex --
-    // holding it across that await would deadlock the whole app the moment
-    // there's at least one enabled server.
+    // Scoped so the DB lock is released before the concurrent fetches below.
     let enabled_servers: Vec<_> = {
         let db = state.0.lock().await;
         let servers = db
@@ -545,11 +566,36 @@ pub async fn get_all_mcp_tools(state: tauri::State<'_, DbState>) -> Result<Vec<M
         servers.into_iter().filter(|s| s.enabled).collect()
     };
 
+    // Fetch every server concurrently instead of one-at-a-time -- a serial
+    // loop means N servers each pay their own worst-case latency back to
+    // back, which compounds fast once there's more than one.
+    let fetches = enabled_servers.into_iter().map(|server| async move {
+        if let Some((tools, cached_at)) = MCP_TOOLS_CACHE.lock().await.get(&server.id) {
+            if cached_at.elapsed() < MCP_TOOLS_CACHE_TTL {
+                return (server.id, Ok(tools.clone()));
+            }
+        }
+
+        let result = match server.server_type {
+            MCPServerType::Stdio => call_mcp_tools_stdio(&server).await,
+            MCPServerType::HTTP | MCPServerType::SSE => call_mcp_tools_http(&server).await,
+        };
+
+        if let Ok(ref tools) = result {
+            MCP_TOOLS_CACHE
+                .lock()
+                .await
+                .insert(server.id.clone(), (tools.clone(), Instant::now()));
+        }
+
+        (server.id, result)
+    });
+
     let mut all_tools = Vec::new();
-    for server in enabled_servers {
-        match get_mcp_tools(state.clone(), server.id.clone()).await {
+    for (server_id, result) in futures::future::join_all(fetches).await {
+        match result {
             Ok(tools) => all_tools.extend(tools),
-            Err(e) => log::warn!("Failed to get tools from server {}: {}", server.id, e),
+            Err(e) => log::warn!("Failed to get tools from server {}: {}", server_id, e),
         }
     }
 

--- a/src/stores/lmStudio.ts
+++ b/src/stores/lmStudio.ts
@@ -50,8 +50,10 @@ export const useLMStudioStore = defineStore(
   () => {
     // ============ 响应式状态 ============
 
-    /** LM Studio 服务器地址 (不含 /v1，由各命令自行拼接路径) */
-    const baseUrl = ref("http://localhost:1234");
+    /** LM Studio 服务器地址 (不含 /v1，由各命令自行拼接路径)
+     *  用 127.0.0.1 而非 localhost：部分 Windows 网络环境 (装了 VPN 虚拟
+     *  网卡、IPv6 配置异常等) 解析 "localhost" 会有明显额外延迟。 */
+    const baseUrl = ref("http://127.0.0.1:1234");
 
     /** 可选的 API Key (仅当用户在 LM Studio 中开启了 "Require API key" 时需要) */
     const apiKey = ref("");


### PR DESCRIPTION
## Summary

排查"软件内调用本地部署模型（Ollama/LM Studio）比直接调用 TTFT（首字延迟）明显更高"的问题，定位到三处拖慢首字延迟的点并修复：

- **HTTP 客户端默认走系统代理**：`create_http_client`/`create_streaming_http_client`（`llm.rs`）、`create_lmstudio_client`（`lmstudio.rs`）、`create_ollama_client`/`create_download_client`/Ollama 服务启停探测（`local_model.rs`）新增回环地址（localhost/127.0.0.1/::1）识别，命中时调用 `.no_proxy()` 绕开系统代理——用户为访问境外服务商开启的全局代理会把本该直连本机的请求也绕出去一圈，白白拖慢 TTFT。
- **LM Studio 默认地址用 `localhost`**：部分 Windows 网络环境（装了 VPN 虚拟网卡、IPv6 配置异常等）解析 `localhost` 有明显额外延迟，默认地址改为 `127.0.0.1`（`src/stores/lmStudio.ts`）。
- **MCP 工具列表每轮对话都重新拉取**：`get_all_mcp_tools`（`mcp.rs`）在 `stream_message` 的每一轮都会调用，此前是串行逐个请求已启用的 MCP 服务器（stdio 服务器意味着每次都要起停一个子进程），直接叠加进 TTFT。现在改为并发拉取 + 短 TTL（5 分钟）缓存；请求失败不缓存，避免掩盖故障服务器。

## Test plan

- [x] `pnpm build`（vue-tsc + vite）通过
- [x] `cd src-tauri && cargo build` 通过
- [x] `pnpm tauri build` 生产构建通过（NSIS 安装包正常产出；末尾更新签名报错是本机缺 `TAURI_SIGNING_PRIVATE_KEY` 环境变量，与本次改动无关）
- [x] 用 CDP driver 实测跑通：
  - 本地部署页確認 Ollama 在线检测正常（走了新的 `no_proxy` 客户端路径）
  - MCP 服务管理页正常渲染；日志确认两个 stdio MCP 服务器的 `tools/list` 请求在同一秒内并发发起（而非此前的串行），且请求失败时未写入缓存、下一轮对话正确重试
  - 对比了改动前/后的原始代码：定位到一个和本次改动**无关**的既有 bug（本地模型对话点发送必现 `invalid args request for command stream_message: missing field apiKey`，原始代码同样复现，是 `chat.ts` 里 `apiKey: config.apiKey` 为 `undefined` 时被 JSON 序列化丢弃字段导致），不在本 PR 修复范围内，后续单独跟进

🤖 Generated with [Claude Code](https://claude.com/claude-code)
