### PR TITLE
fix: 修复 Beta 版自动更新检测失效，新增设置页手动检测版本入口

### DIFF
--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -1,0 +1,48 @@
+# 当某个 v* 版本的 Release 由人工点击 "Publish release" 从草稿转正后触发。
+# 把该 Release 里的 latest.json 复制一份到固定 tag "updater-manifest" 下的独立
+# Release，供 tauri-plugin-updater 用一个不受 "prerelease" 影响的固定 URL 查询。
+#
+# 背景：GitHub 的 `/releases/latest` 解析规则里，prerelease 永远不会被视为
+# latest release；而本项目所有 beta 版本都在 release.yml 里打了 prerelease
+# 标签（用于在 GitHub UI 上和正式版区分），导致 updater.ts 原来查询的
+# `.../releases/latest/download/latest.json` 端点一直 404，自动更新形同虚设。
+# 这里额外维护一个固定 tag 的"清单专用" Release：它本身不是 prerelease，
+# 但 latest.json 里记录的下载地址仍然指向原始版本 Release 的真实资产，
+# 不影响 GitHub Releases 页面上 beta 版本的 Pre-release 标签展示。
+name: Publish update manifest
+
+on:
+  release:
+    types: [published]
+  # 补跑用：对已经发布过、但错过本 workflow 的历史版本（比如上线本改动之前发布的
+  # beta.1~beta.4）手动指定 tag 补发一次 updater-manifest
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: '要同步 latest.json 的已发布 Release 标签，例如 v0.2.0-beta.4'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish-update-manifest:
+    # updater-manifest 自身的 Release 不以 v 开头，避免被这个 workflow 自己触发出死循环
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TARGET_TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+    steps:
+      - name: Download latest.json from the published release
+        run: gh release download "$TARGET_TAG" --repo ${{ github.repository }} --pattern latest.json --dir manifest --clobber
+
+      - name: Ensure fixed updater-manifest release exists
+        run: |
+          gh release view updater-manifest --repo ${{ github.repository }} || \
+          gh release create updater-manifest --repo ${{ github.repository }} \
+            --title "自动更新清单（请勿删除）" \
+            --notes "仅供应用内自动更新读取 latest.json，不代表实际版本发布，安装包请在正式版本 Release 里下载。"
+
+      - name: Publish latest.json to the fixed release
+        run: gh release upload updater-manifest manifest/latest.json --repo ${{ github.repository }} --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 # Windows 额外附带一份便携版单文件 exe（未打包的原始二进制，免安装双击运行）
 # 用法：git tag v0.1.0 && git push origin v0.1.0
 # 打完后到 GitHub Releases 页面检查草稿，确认没问题再手动发布
+# 手动发布后会触发 publish-update-manifest.yml，把 latest.json 同步到应用内自动更新用的固定端点
 name: Release
 
 on:

--- a/src-tauri/src/commands/app_update.rs
+++ b/src-tauri/src/commands/app_update.rs
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! 设置页"检测最新版本"按钮用：查询 GitHub Releases，分别找出最新正式版
+//! 和最新 Beta 版，连同各自 Release 页面上的更新说明一起返回给前端展示。
+//! 这是纯信息查询，不涉及下载/安装（安装走 tauri-plugin-updater 的
+//! updater-manifest 端点），因此直接用总超时即可，不需要读间隔超时。
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+const GITHUB_RELEASES_API: &str = "https://api.github.com/repos/baiyuheniao/BaiyuAISpace2/releases";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    name: Option<String>,
+    body: Option<String>,
+    html_url: String,
+    published_at: Option<String>,
+    prerelease: bool,
+    draft: bool,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseInfo {
+    pub version: String,
+    pub name: String,
+    pub body: String,
+    pub html_url: String,
+    pub published_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LatestReleasesResult {
+    pub current_version: String,
+    pub stable: Option<ReleaseInfo>,
+    pub beta: Option<ReleaseInfo>,
+}
+
+impl From<&GithubRelease> for ReleaseInfo {
+    fn from(r: &GithubRelease) -> Self {
+        ReleaseInfo {
+            version: r.tag_name.trim_start_matches('v').to_string(),
+            name: r
+                .name
+                .clone()
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| r.tag_name.clone()),
+            body: r.body.clone().unwrap_or_default(),
+            html_url: r.html_url.clone(),
+            published_at: r.published_at.clone(),
+        }
+    }
+}
+
+/// 检测 GitHub 上最新的正式版和 Beta 版
+#[tauri::command]
+pub async fn check_latest_releases() -> Result<LatestReleasesResult, String> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    // GitHub API 要求请求带 User-Agent，否则一律拒绝
+    let resp = client
+        .get(GITHUB_RELEASES_API)
+        .header("User-Agent", "BaiyuAISpace2")
+        .header("Accept", "application/vnd.github+json")
+        .query(&[("per_page", "20")])
+        .send()
+        .await
+        .map_err(|e| format!("请求 GitHub Releases 失败: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("GitHub 返回错误状态: {}", resp.status()));
+    }
+
+    let releases: Vec<GithubRelease> = resp
+        .json()
+        .await
+        .map_err(|e| format!("解析 GitHub Releases 响应失败: {e}"))?;
+
+    // 列表按发布时间从新到旧排列；跳过草稿和"仅供更新清单用"的固定 tag
+    let releases: Vec<&GithubRelease> = releases
+        .iter()
+        .filter(|r| !r.draft && r.tag_name != "updater-manifest")
+        .collect();
+
+    let stable = releases.iter().find(|r| !r.prerelease).map(|r| ReleaseInfo::from(*r));
+    let beta = releases.iter().find(|r| r.prerelease).map(|r| ReleaseInfo::from(*r));
+
+    Ok(LatestReleasesResult {
+        current_version: env!("CARGO_PKG_VERSION").to_string(),
+        stable,
+        beta,
+    })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@
  * - skills: Skill (技能) 管理命令
  */
 
+pub mod app_update;
 pub mod auth;
 pub mod constants;
 pub mod docker;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -194,6 +194,8 @@ fn main() {
             commands::llm::cancel_stream,
             // Auth commands
             commands::auth::get_baidu_access_token,
+            // 检测最新版本(设置页手动检测按钮)
+            commands::app_update::check_latest_releases,
             // 数据库相关命令
             save_session_cmd,
             save_message_cmd,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVENUI3RkQ3MjAwQjQ4MkEKUldRcVNBc2cxMzliWFRpYVYwUU85UHpWNFV4OTJHd29uTUptMjRRak9Eam1TYkNLTWpsM1E4SHkK",
       "endpoints": [
-        "https://github.com/baiyuheniao/BaiyuAISpace2/releases/latest/download/latest.json"
+        "https://github.com/baiyuheniao/BaiyuAISpace2/releases/download/updater-manifest/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -136,6 +136,52 @@ const renderReleaseNotes = (body: string): string => {
   return DOMPurify.sanitize(html);
 };
 
+/**
+ * 简化版 semver 比较：核心版本号（major.minor.patch）逐段比较；核心相同时，
+ * 不带 -beta.N 后缀的正式版视为比任何 beta 都新，两边都有后缀则逐段比较
+ * （数字段按数值比，否则按字典序）。返回值同 Array.sort 的比较器语义。
+ * 用于判断 GitHub 上查到的版本是否比本地正在运行的版本更新——不能简单用
+ * 字符串不等于判断，否则本地跑着尚未发布的开发版（比如 beta.5）时，
+ * 会把已发布的旧版本（beta.4）误判成"有新版本"。
+ */
+const compareVersions = (a: string, b: string): number => {
+  const parse = (v: string) => {
+    const dashIndex = v.indexOf("-");
+    const core = dashIndex === -1 ? v : v.slice(0, dashIndex);
+    const pre = dashIndex === -1 ? null : v.slice(dashIndex + 1).split(".");
+    return { core: core.split(".").map((n) => Number.parseInt(n, 10) || 0), pre };
+  };
+  const va = parse(a);
+  const vb = parse(b);
+
+  for (let i = 0; i < Math.max(va.core.length, vb.core.length); i++) {
+    const diff = (va.core[i] ?? 0) - (vb.core[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  if (va.pre === null && vb.pre === null) return 0;
+  if (va.pre === null) return 1;
+  if (vb.pre === null) return -1;
+
+  for (let i = 0; i < Math.max(va.pre.length, vb.pre.length); i++) {
+    const sa = va.pre[i];
+    const sb = vb.pre[i];
+    if (sa === undefined) return -1;
+    if (sb === undefined) return 1;
+    const na = Number(sa);
+    const nb = Number(sb);
+    if (!Number.isNaN(na) && !Number.isNaN(nb)) {
+      if (na !== nb) return na - nb;
+    } else if (sa !== sb) {
+      return sa < sb ? -1 : 1;
+    }
+  }
+  return 0;
+};
+
+const isNewerVersion = (remoteVersion: string): boolean =>
+  compareVersions(remoteVersion, currentAppVersion.value) > 0;
+
 const checkLatestVersion = async () => {
   checkingUpdate.value = true;
   try {
@@ -1692,9 +1738,9 @@ const providerOptions = computed(() => settings.presetProviderOptions);
                 <n-tag size="small">v{{ section.info.version }}</n-tag>
                 <n-tag
                   size="small"
-                  :type="section.info.version === currentAppVersion ? 'default' : 'success'"
+                  :type="isNewerVersion(section.info.version) ? 'success' : 'default'"
                 >
-                  {{ section.info.version === currentAppVersion ? "已是最新" : "有新版本" }}
+                  {{ isNewerVersion(section.info.version) ? "有新版本" : "已是最新" }}
                 </n-tag>
                 <n-button
                   text

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -20,9 +20,13 @@
 -->
 
 <script setup lang="ts">
-import { ref, computed, onBeforeUnmount } from "vue";
+import { ref, computed, onBeforeUnmount, onMounted } from "vue";
 import { invoke } from "@tauri-apps/api/core";
+import { getVersion } from "@tauri-apps/api/app";
 import { save } from "@tauri-apps/plugin-dialog";
+import { open as openExternalUrl } from "@tauri-apps/plugin-shell";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
 import { 
   NLayout, 
   NLayoutContent, 
@@ -93,6 +97,63 @@ const exportLogs = async () => {
   } catch (error) {
     message.error("导出日志失败: " + error);
   }
+};
+
+// ============ 检测最新版本 ============
+
+interface ReleaseInfo {
+  version: string;
+  name: string;
+  body: string;
+  htmlUrl: string;
+  publishedAt: string | null;
+}
+
+interface LatestReleasesResult {
+  currentVersion: string;
+  stable: ReleaseInfo | null;
+  beta: ReleaseInfo | null;
+}
+
+/** 当前运行的应用版本号，启动时读取一次用于展示和比对 */
+const currentAppVersion = ref("");
+
+onMounted(async () => {
+  try {
+    currentAppVersion.value = await getVersion();
+  } catch {
+    // 读取失败不影响其他功能，留空即可
+  }
+});
+
+const checkingUpdate = ref(false);
+const showUpdateModal = ref(false);
+const latestReleases = ref<LatestReleasesResult | null>(null);
+
+/** 更新内容以对应 GitHub Release 页面的原文为准，用 marked 渲染成 HTML 再净化 */
+const renderReleaseNotes = (body: string): string => {
+  const html = marked.parse(body.trim() || "暂无更新说明。", { async: false, breaks: true }) as string;
+  return DOMPurify.sanitize(html);
+};
+
+const checkLatestVersion = async () => {
+  checkingUpdate.value = true;
+  try {
+    latestReleases.value = await invoke<LatestReleasesResult>("check_latest_releases");
+    if (!latestReleases.value.stable && !latestReleases.value.beta) {
+      message.warning("未能获取到任何已发布的版本信息");
+      return;
+    }
+    showUpdateModal.value = true;
+  } catch (error) {
+    message.error("检测最新版本失败: " + error);
+  } finally {
+    checkingUpdate.value = false;
+  }
+};
+
+const openReleasePage = (url: string) => {
+  void openExternalUrl(url);
 };
 
 // ============ 弹窗状态 ============
@@ -1071,7 +1132,7 @@ const providerOptions = computed(() => settings.presetProviderOptions);
                 type="success"
                 size="small"
               >
-                v0.1.0
+                v{{ currentAppVersion || "…" }}
               </n-tag>
             </div>
             <div class="about-item">
@@ -1097,13 +1158,23 @@ const providerOptions = computed(() => settings.presetProviderOptions);
               class="about-item"
               style="margin-top: 16px;"
             >
-              <n-button 
-                type="primary" 
-                size="small"
-                @click="exportLogs"
-              >
-                导出日志
-              </n-button>
+              <n-space>
+                <n-button
+                  type="primary"
+                  size="small"
+                  :loading="checkingUpdate"
+                  @click="checkLatestVersion"
+                >
+                  检测最新版本
+                </n-button>
+                <n-button
+                  type="primary"
+                  size="small"
+                  @click="exportLogs"
+                >
+                  导出日志
+                </n-button>
+              </n-space>
             </div>
           </div>
         </n-card>
@@ -1595,6 +1666,62 @@ const providerOptions = computed(() => settings.presetProviderOptions);
       </template>
     </n-modal>
 
+    <!-- 检测最新版本弹窗 -->
+    <n-modal
+      v-model:show="showUpdateModal"
+      title="版本检测结果"
+      preset="card"
+      style="width: 640px; max-width: 90vw;"
+    >
+      <div class="version-check-body">
+        <div class="version-check-current">
+          当前版本：<n-tag size="small">v{{ currentAppVersion }}</n-tag>
+        </div>
+
+        <template
+          v-for="section in [
+            { label: '最新正式版', info: latestReleases?.stable },
+            { label: '最新 Beta 版', info: latestReleases?.beta },
+          ]"
+          :key="section.label"
+        >
+          <div class="version-check-section">
+            <div class="version-check-section-header">
+              <span class="version-check-section-label">{{ section.label }}</span>
+              <template v-if="section.info">
+                <n-tag size="small">v{{ section.info.version }}</n-tag>
+                <n-tag
+                  size="small"
+                  :type="section.info.version === currentAppVersion ? 'default' : 'success'"
+                >
+                  {{ section.info.version === currentAppVersion ? "已是最新" : "有新版本" }}
+                </n-tag>
+                <n-button
+                  text
+                  size="small"
+                  class="version-check-link"
+                  @click="openReleasePage(section.info.htmlUrl)"
+                >
+                  在 GitHub 中查看
+                </n-button>
+              </template>
+            </div>
+
+            <n-empty
+              v-if="!section.info"
+              description="GitHub 上暂无对应版本发布"
+              size="small"
+            />
+            <div
+              v-else
+              class="version-check-notes"
+              v-html="renderReleaseNotes(section.info.body)"
+            />
+          </div>
+        </template>
+      </div>
+    </n-modal>
+
   </n-layout>
 </template>
 
@@ -1700,4 +1827,70 @@ const providerOptions = computed(() => settings.presetProviderOptions);
   font-weight: 600;
 }
 
+/* 检测最新版本弹窗 */
+.version-check-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.version-check-current {
+  font-size: 14px;
+  color: $ink-soft;
+}
+
+.version-check-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: $border-faint;
+}
+
+.version-check-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.version-check-section-label {
+  font-weight: 600;
+}
+
+.version-check-link {
+  margin-left: auto;
+}
+
+.version-check-notes {
+  font-size: 13px;
+  line-height: $leading-body;
+  color: $ink-soft;
+  max-height: 260px;
+  overflow-y: auto;
+
+  :deep(h1),
+  :deep(h2),
+  :deep(h3) {
+    font-size: 14px;
+    font-weight: 600;
+    color: $ink;
+    margin: 8px 0 4px;
+  }
+
+  :deep(ul),
+  :deep(ol) {
+    padding-left: 20px;
+  }
+
+  :deep(a) {
+    color: $ink;
+  }
+
+  :deep(code) {
+    font-family: $font-mono;
+    background: $surface;
+    padding: 1px 4px;
+  }
+}
 </style>


### PR DESCRIPTION
## 背景

排查 Beta3 自动更新不提示的问题，发现根因跟具体版本无关：GitHub 的 `/releases/latest` 解析规则永远排除 prerelease，而本项目所有 beta 版本发布时都会打上 prerelease 标签（`release.yml` 里 `prerelease: contains(github.ref_name, '-')`），导致 updater 端点 `.../releases/latest/download/latest.json` 长期 404，beta.1~beta.4 全部中招。

## 修复方案

按要求：Beta 版本要能收到更新提示，同时 GitHub 上继续保留 Pre-release 标签。

- 新增 `.github/workflows/publish-update-manifest.yml`：在人工把 Release 从草稿"Publish"为正式发布后触发（`release: published` 事件，保留原有的人工审核 gate），把该 Release 的 `latest.json` 复制到一个固定 tag（`updater-manifest`）下的独立 Release。该 Release 本身不是 prerelease，但 `latest.json` 里记录的下载地址仍指向原始版本 Release 的真实资产，不影响 GitHub UI 上 beta 版本的 Pre-release 标签展示。
- 附带 `workflow_dispatch` 手动触发入口，用于给已发布但错过这次修复的历史版本（beta.1~beta.4）补跑一次。
- `tauri.conf.json` 的 updater 端点改为指向这个固定地址，不再依赖会排除 prerelease 的 `/releases/latest/` 解析。

## 顺带需求

设置页"关于"卡片新增"检测最新版本"按钮：

- 后端新增 `check_latest_releases` command，查询 GitHub Releases API，分别取最新正式版和最新 Beta 版（当前项目还没有正式版）。
- 前端弹窗展示两者的版本号、是否有更新，以及对应 Release 页面的更新说明原文（`marked` 渲染 + `DOMPurify` 净化）。
- 顺手把"关于"卡片里写死的 `v0.1.0` 版本号改成读取真实运行版本。

## 验证

- `pnpm build`（vue-tsc + vite）通过
- `cargo build`（debug）通过
- `pnpm tauri build`：Rust release 编译成功、NSIS 安装包打包成功；最后一步"生成 updater 签名"因本地缺少 `TAURI_SIGNING_PRIVATE_KEY`（仅存在于 CI secrets）报错退出，属本地环境固有限制，与本次改动无关（该签名步骤只在 CI 里跑）。

## 后续手动步骤

这个 PR 合并后，下一次正式发布某个 beta 版本时会自动生效。**对已经发布的 beta.4（当前用户装的 beta.3 也需要补上）**，合并后需要在 GitHub Actions 页面手动跑一次 `Publish update manifest` workflow（`workflow_dispatch`，输入 `tag_name: v0.2.0-beta.4`），否则装着旧版本的用户要等到下一个 beta 发布才会收到更新提示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)