### PR TITLE
fix: 更新清单 Release 不再顶替 Latest release

### DIFF
--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -42,7 +42,8 @@ jobs:
           gh release view updater-manifest --repo ${{ github.repository }} || \
           gh release create updater-manifest --repo ${{ github.repository }} \
             --title "自动更新清单（请勿删除）" \
-            --notes "仅供应用内自动更新读取 latest.json，不代表实际版本发布，安装包请在正式版本 Release 里下载。"
+            --notes "仅供应用内自动更新读取 latest.json，不代表实际版本发布，安装包请在正式版本 Release 里下载。" \
+            --prerelease --latest=false
 
       - name: Publish latest.json to the fixed release
         run: gh release upload updater-manifest manifest/latest.json --repo ${{ github.repository }} --clobber


### PR DESCRIPTION
## 问题

今早发布 beta.7 后，仓库主页 "Latest release" 显示的是 `updater-manifest`（自动更新清单），而不是 beta.7。

## 原因

`.github/workflows/publish-update-manifest.yml` 用 `gh release create updater-manifest` 创建固定 tag 的更新清单 Release 时，没有加 `--prerelease`/`--latest=false`。GitHub 判定 "Latest release" 的规则是：在**非 prerelease 且非 draft** 的 Release 里挑发布时间最新的一个。项目里所有正式的版本 Release（v0.2.0-beta.x）都标了 prerelease，唯独 updater-manifest 没标，于是它被 GitHub 判定为 latest，把"仅供自动更新读取的清单"顶替了真正的最新 Beta 版展示出来。

## 修复

给 `gh release create updater-manifest` 加上 `--prerelease --latest=false`，往后新建的 updater-manifest 就不会再被 GitHub 判定为 latest。

## 遗留手动步骤

现有的 `updater-manifest` Release 是历史遗留创建的，这次修复只影响**未来**新建的情况，不会回溯改已存在的 Release 状态。需要仓库所有者手动去 GitHub 上把现有 `updater-manifest` Release 编辑一下：
1. 打开 https://github.com/baiyuheniao/BaiyuAISpace2/releases/tag/updater-manifest → Edit release
2. 勾选 "Set as a pre-release"
3. 取消勾选 "Set as the latest release"
4. Save

这一步无法通过现有的 MCP/工具自动完成（没有可用的"更新 Release 元数据"接口），需要手工点一下。

## 影响范围确认

不影响自动更新功能本身：`tauri.conf.json` 里 updater 的 endpoint 直接写死指向 `releases/download/updater-manifest/latest.json` 这个固定 tag 的下载 URL，不经过 `/releases/latest` 解析，所以改 prerelease 状态不会让自动更新失效。