### PR TITLE
feat: 修复 Agent Team Mode 剩余的 12 项结构性问题

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -270,6 +270,7 @@ fn main() {
             workspace::commands::workspace_delete,
             workspace::commands::workspace_create_agent_manual,
             workspace::commands::workspace_list_agents,
+            workspace::commands::workspace_update_agent,
             workspace::commands::workspace_delete_agent,
             workspace::commands::workspace_send_user_message,
             workspace::commands::workspace_list_messages,
@@ -277,6 +278,7 @@ fn main() {
             workspace::commands::workspace_resolve_proposal,
             workspace::commands::workspace_resolve_sleep_request,
             workspace::commands::workspace_resolve_question,
+            workspace::commands::workspace_list_pending_events,
             // 定时任务命令
             scheduler::commands::schedule_create,
             scheduler::commands::schedule_list,
@@ -353,7 +355,44 @@ fn main() {
                 vector_store: Arc::new(vector_store),
                 db_path,
             });
-            app.manage(WorkspaceState::default());
+            // Agent 循环只存在于内存里，之前重启应用后永远拿不回来，用户只能
+            // 删了重建。这里把每个工作组里所有存活（未软删除）的 Agent 重新
+            // 挂回一个新的后台循环——Running/WaitingApproval/WaitingAnswer/
+            // Meeting 这几个状态绑定的 oneshot/会议协调器都是旧进程里的东西，
+            // 已经无法恢复，重置为 Idle；Sleeping 是稳定的持久状态，不用动，
+            // 新消息来了新循环自然会唤醒它。
+            let workspace_state = WorkspaceState::default();
+            {
+                use workspace::db as ws_db;
+                use workspace::types::AgentStatus;
+                match ws_db::list_workspaces(&conn) {
+                    Ok(workspaces) => {
+                        let mut resumed = 0;
+                        for ws in workspaces {
+                            let agents = ws_db::list_agents(&conn, &ws.id).unwrap_or_default();
+                            for mut agent in agents {
+                                if matches!(
+                                    agent.status,
+                                    AgentStatus::Running
+                                        | AgentStatus::WaitingApproval
+                                        | AgentStatus::WaitingAnswer
+                                        | AgentStatus::Meeting
+                                ) {
+                                    if let Err(e) = ws_db::update_agent_status(&conn, &agent.id, AgentStatus::Idle) {
+                                        log::error!("恢复 Agent 循环时重置状态失败: {}", e);
+                                    }
+                                    agent.status = AgentStatus::Idle;
+                                }
+                                workspace::commands::start_agent_loop(app.handle().clone(), workspace_state.0.clone(), agent);
+                                resumed += 1;
+                            }
+                        }
+                        log::info!("应用启动：已恢复 {} 个 Agent 的后台循环", resumed);
+                    }
+                    Err(e) => log::error!("恢复 Agent 循环失败（列出工作组）: {}", e),
+                }
+            }
+            app.manage(workspace_state);
             app.manage(PendingProposals::default());
             app.manage(PendingSleepRequests::default());
             app.manage(PendingQuestions::default());

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -32,10 +32,10 @@ const MAX_ROUNDS_PER_WAKE: u32 = 8;
 const MAX_TOTAL_ROUNDS_PER_WAKE: u32 = 500;
 const MAX_HISTORY_MESSAGES: i64 = 40;
 
-/// One running agent's wake signal + stop switch. Lives only in memory --
-/// restarting the app currently does not resume agent loops, only their
-/// persisted DB state (Phase 1 scope; auto-resume on launch is not yet
-/// implemented).
+/// One running agent's wake signal + stop switch. Lives only in memory, but
+/// `main.rs`'s `setup()` calls `start_agent_loop` again for every active
+/// agent on launch (via this same function), so a restart resumes every
+/// workspace's agents rather than leaving them permanently dormant.
 pub struct AgentHandle {
     pub notify: Arc<Notify>,
     pub cancel: CancellationToken,
@@ -98,7 +98,7 @@ pub async fn workspace_create(
         updated_at: now,
     };
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+    let conn = db::open_conn(&db.path)?;
     db::insert_workspace(&conn, &workspace)?;
     Ok(workspace)
 }
@@ -106,7 +106,7 @@ pub async fn workspace_create(
 #[tauri::command]
 pub async fn workspace_list(db_state: State<'_, DbState>) -> Result<Vec<Workspace>, WorkspaceError> {
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+    let conn = db::open_conn(&db.path)?;
     db::list_workspaces(&conn)
 }
 
@@ -119,7 +119,7 @@ pub async fn workspace_delete(
 ) -> Result<(), WorkspaceError> {
     let agent_ids: Vec<String> = {
         let db = db_state.0.lock().await;
-        let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+        let conn = db::open_conn(&db.path)?;
         db::list_agents(&conn, &workspace_id)?.into_iter().map(|a| a.id).collect()
     };
 
@@ -140,7 +140,7 @@ pub async fn workspace_delete(
     }
 
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+    let conn = db::open_conn(&db.path)?;
     db::delete_workspace(&conn, &workspace_id)?;
     Ok(())
 }
@@ -159,14 +159,36 @@ pub async fn workspace_create_agent_manual(
     spawn_agent_internal(&app_handle, workspace_state.0.clone(), request).await
 }
 
+/// Returns every agent including soft-deleted ones -- the frontend needs the
+/// deleted ones too, to resolve sender names in historical messages/logs
+/// instead of showing a raw UUID; it filters them back out of the active
+/// roster/dropdowns itself using `deletedAt`.
 #[tauri::command]
 pub async fn workspace_list_agents(
     workspace_id: String,
     db_state: State<'_, DbState>,
 ) -> Result<Vec<WorkspaceAgent>, WorkspaceError> {
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
-    db::list_agents(&conn, &workspace_id)
+    let conn = db::open_conn(&db.path)?;
+    db::list_agents_including_deleted(&conn, &workspace_id)
+}
+
+/// Applies user edits to an existing agent (name/model/prompt/tool access/RAG
+/// config). Deliberately doesn't restart the agent's background loop --
+/// `process_agent_wake` reloads the agent row from the DB at the start of
+/// every wake, so a plain config update takes effect on its very next turn.
+#[tauri::command]
+pub async fn workspace_update_agent(
+    request: UpdateAgentRequest,
+    db_state: State<'_, DbState>,
+) -> Result<WorkspaceAgent, WorkspaceError> {
+    if request.name.trim().is_empty() || request.provider.trim().is_empty() || request.model.trim().is_empty() {
+        return Err(WorkspaceError::InvalidConfig("name/provider/model 不能为空".to_string()));
+    }
+    let db = db_state.0.lock().await;
+    let conn = db::open_conn(&db.path)?;
+    db::update_agent(&conn, &request)?;
+    db::get_agent(&conn, &request.id)?.ok_or_else(|| WorkspaceError::AgentNotFound(request.id.clone()))
 }
 
 #[tauri::command]
@@ -182,7 +204,7 @@ pub async fn workspace_delete_agent(
         }
     }
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+    let conn = db::open_conn(&db.path)?;
     db::delete_agent(&conn, &agent_id)?;
     Ok(())
 }
@@ -229,21 +251,23 @@ pub async fn workspace_send_user_message(
 #[tauri::command]
 pub async fn workspace_list_messages(
     workspace_id: String,
+    limit: Option<i64>,
     db_state: State<'_, DbState>,
 ) -> Result<Vec<WorkspaceMessage>, WorkspaceError> {
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
-    db::list_messages(&conn, &workspace_id, 500)
+    let conn = db::open_conn(&db.path)?;
+    db::list_messages(&conn, &workspace_id, limit.unwrap_or(500))
 }
 
 #[tauri::command]
 pub async fn workspace_list_logs(
     workspace_id: String,
+    limit: Option<i64>,
     db_state: State<'_, DbState>,
 ) -> Result<Vec<WorkspaceLogEntry>, WorkspaceError> {
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
-    db::list_logs(&conn, &workspace_id, 500)
+    let conn = db::open_conn(&db.path)?;
+    db::list_logs(&conn, &workspace_id, limit.unwrap_or(500))
 }
 
 /// The frontend calls this in response to a `workspace://agent-proposal`
@@ -257,6 +281,7 @@ pub async fn workspace_resolve_proposal(
     approved: bool,
     request: Option<CreateAgentRequest>,
     pending: State<'_, PendingProposals>,
+    db_state: State<'_, DbState>,
 ) -> Result<(), WorkspaceError> {
     let sender = {
         let mut map = pending.0.lock().unwrap();
@@ -280,6 +305,7 @@ pub async fn workspace_resolve_proposal(
     };
 
     let _ = sender.send(decision);
+    mark_pending_event_resolved(&db_state, &proposal_id).await;
     Ok(())
 }
 
@@ -293,6 +319,7 @@ pub async fn workspace_resolve_sleep_request(
     request_id: String,
     approved: bool,
     pending: State<'_, PendingSleepRequests>,
+    db_state: State<'_, DbState>,
 ) -> Result<(), WorkspaceError> {
     let sender = {
         let mut map = pending.0.lock().unwrap();
@@ -302,6 +329,7 @@ pub async fn workspace_resolve_sleep_request(
         WorkspaceError::NotFound(format!("休眠请求 {} 不存在或已被处理/超时", request_id))
     })?;
     let _ = sender.send(approved);
+    mark_pending_event_resolved(&db_state, &request_id).await;
     Ok(())
 }
 
@@ -312,6 +340,7 @@ pub async fn workspace_resolve_question(
     question_id: String,
     answer: String,
     pending: State<'_, PendingQuestions>,
+    db_state: State<'_, DbState>,
 ) -> Result<(), WorkspaceError> {
     let sender = {
         let mut map = pending.0.lock().unwrap();
@@ -321,7 +350,69 @@ pub async fn workspace_resolve_question(
         WorkspaceError::NotFound(format!("问题 {} 不存在或已被处理/超时", question_id))
     })?;
     let _ = sender.send(answer);
+    mark_pending_event_resolved(&db_state, &question_id).await;
     Ok(())
+}
+
+/// Lists everything in this workspace still awaiting a human decision -- the
+/// frontend fetches this on selecting a workspace so a proposal/sleep
+/// request/question raised while the page wasn't open (or the app wasn't
+/// running) isn't lost, unlike the one-shot events these are paired with.
+#[tauri::command]
+pub async fn workspace_list_pending_events(
+    workspace_id: String,
+    db_state: State<'_, DbState>,
+) -> Result<Vec<WorkspacePendingEvent>, WorkspaceError> {
+    let db = db_state.0.lock().await;
+    let conn = db::open_conn(&db.path)?;
+    db::list_unresolved_pending_events(&conn, &workspace_id)
+}
+
+async fn mark_pending_event_resolved(db_state: &DbState, id: &str) {
+    let db = db_state.0.lock().await;
+    match db::open_conn(&db.path) {
+        Ok(conn) => {
+            if let Err(e) = db::resolve_pending_event(&conn, id) {
+                log::error!("[workspace] 标记待处理事项已解决失败: {}", e);
+            }
+        }
+        Err(e) => log::error!("[workspace] 打开数据库连接失败（标记待处理事项）: {}", e),
+    }
+}
+
+async fn mark_pending_event_resolved_via_handle(app_handle: &AppHandle, id: &str) {
+    mark_pending_event_resolved(&app_handle.state::<DbState>(), id).await;
+}
+
+async fn record_pending_event(
+    app_handle: &AppHandle,
+    workspace_id: &str,
+    agent_id: &str,
+    agent_name: &str,
+    kind: &str,
+    payload: serde_json::Value,
+    id: &str,
+) {
+    let event = WorkspacePendingEvent {
+        id: id.to_string(),
+        workspace_id: workspace_id.to_string(),
+        agent_id: agent_id.to_string(),
+        agent_name: agent_name.to_string(),
+        kind: kind.to_string(),
+        payload,
+        created_at: Utc::now().timestamp_millis(),
+        resolved_at: None,
+    };
+    let db_state = app_handle.state::<DbState>();
+    let db = db_state.0.lock().await;
+    match db::open_conn(&db.path) {
+        Ok(conn) => {
+            if let Err(e) = db::insert_pending_event(&conn, &event) {
+                log::error!("[workspace] 持久化待处理事项失败: {}", e);
+            }
+        }
+        Err(e) => log::error!("[workspace] 打开数据库连接失败（持久化待处理事项）: {}", e),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -331,14 +422,14 @@ pub async fn workspace_resolve_question(
 pub(crate) async fn load_agent(app_handle: &AppHandle, agent_id: &str) -> Result<Option<WorkspaceAgent>, WorkspaceError> {
     let db_state = app_handle.state::<DbState>();
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+    let conn = db::open_conn(&db.path)?;
     db::get_agent(&conn, agent_id)
 }
 
 async fn load_workspace(app_handle: &AppHandle, workspace_id: &str) -> Result<Option<Workspace>, WorkspaceError> {
     let db_state = app_handle.state::<DbState>();
     let db = db_state.0.lock().await;
-    let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+    let conn = db::open_conn(&db.path)?;
     db::get_workspace(&conn, workspace_id)
 }
 
@@ -346,8 +437,13 @@ pub(crate) async fn set_agent_status(app_handle: &AppHandle, agent_id: &str, sta
     let db_state = app_handle.state::<DbState>();
     {
         let db = db_state.0.lock().await;
-        if let Ok(conn) = rusqlite::Connection::open(&db.path) {
-            let _ = db::update_agent_status(&conn, agent_id, status);
+        match db::open_conn(&db.path) {
+            Ok(conn) => {
+                if let Err(e) = db::update_agent_status(&conn, agent_id, status) {
+                    log::error!("[workspace] 更新 Agent 状态失败: {}", e);
+                }
+            }
+            Err(e) => log::error!("[workspace] 打开数据库连接失败（更新状态）: {}", e),
         }
     }
     let _ = app_handle.emit(
@@ -374,8 +470,13 @@ pub async fn insert_workspace_log(
     let db_state = app_handle.state::<DbState>();
     {
         let db = db_state.0.lock().await;
-        if let Ok(conn) = rusqlite::Connection::open(&db.path) {
-            let _ = db::insert_log(&conn, &entry);
+        match db::open_conn(&db.path) {
+            Ok(conn) => {
+                if let Err(e) = db::insert_log(&conn, &entry) {
+                    log::error!("[workspace] 写入活动日志失败: {}", e);
+                }
+            }
+            Err(e) => log::error!("[workspace] 打开数据库连接失败（写日志）: {}", e),
         }
     }
     let _ = app_handle.emit("workspace://log", &entry);
@@ -436,8 +537,13 @@ async fn send_workspace_message_impl(
     let db_state = app_handle.state::<DbState>();
     {
         let db = db_state.0.lock().await;
-        if let Ok(conn) = rusqlite::Connection::open(&db.path) {
-            let _ = db::insert_message(&conn, &msg);
+        match db::open_conn(&db.path) {
+            Ok(conn) => {
+                if let Err(e) = db::insert_message(&conn, &msg) {
+                    log::error!("[workspace] 写入消息失败: {}", e);
+                }
+            }
+            Err(e) => log::error!("[workspace] 打开数据库连接失败（写消息）: {}", e),
         }
     }
     let _ = app_handle.emit("workspace://message", &msg);
@@ -461,7 +567,7 @@ async fn send_workspace_message_impl(
 async fn list_agents_for_workspace(app_handle: &AppHandle, workspace_id: &str) -> Vec<WorkspaceAgent> {
     let db_state = app_handle.state::<DbState>();
     let db = db_state.0.lock().await;
-    match rusqlite::Connection::open(&db.path) {
+    match db::open_conn(&db.path) {
         Ok(conn) => db::list_agents(&conn, workspace_id).unwrap_or_default(),
         Err(_) => vec![],
     }
@@ -528,7 +634,7 @@ async fn spawn_agent_internal(
     let now = Utc::now().timestamp_millis();
     let agent = {
         let db = db_state.0.lock().await;
-        let conn = rusqlite::Connection::open(&db.path).map_err(|e| WorkspaceError::DatabaseError(e.to_string()))?;
+        let conn = db::open_conn(&db.path)?;
 
         let current_count = db::count_agents(&conn, &workspace.id)?;
         if current_count >= workspace.max_agents as i64 {
@@ -552,6 +658,10 @@ async fn spawn_agent_internal(
             knowledge_base_ids: request.knowledge_base_ids.clone(),
             active_skill_ids: request.active_skill_ids.clone(),
             status: AgentStatus::Idle,
+            rag_top_k: request.rag_top_k,
+            rag_retrieval_mode: request.rag_retrieval_mode.clone(),
+            scratchpad: String::new(),
+            deleted_at: None,
             created_at: now,
             updated_at: now,
         };
@@ -587,7 +697,7 @@ async fn spawn_agent_internal(
 /// `propose_agent_creation` -> `spawn_agent_internal` when a main agent's
 /// proposal gets approved, and an `async fn` here would make that chain
 /// self-referential.
-fn start_agent_loop(app_handle: AppHandle, agent_handles: Arc<Mutex<HashMap<String, AgentHandle>>>, agent: WorkspaceAgent) {
+pub(crate) fn start_agent_loop(app_handle: AppHandle, agent_handles: Arc<Mutex<HashMap<String, AgentHandle>>>, agent: WorkspaceAgent) {
     let notify = Arc::new(Notify::new());
     let cancel = CancellationToken::new();
 
@@ -663,6 +773,15 @@ async fn process_agent_wake(
     let chat_history = build_chat_history(app_handle, workspace_id, &agent).await;
     if chat_history.is_empty() {
         log::debug!("[workspace] Agent「{}」历史消息为空，跳过本次唤醒", agent.name);
+        set_agent_status(app_handle, agent_id, AgentStatus::Idle).await;
+        return Ok(());
+    }
+    // 虚假唤醒去重：`Notify` 的 permit 语义下，处理期间收到的通知会在处理结束
+    // 后再触发一轮唤醒；如果这时最新一条相关消息就是自己上次发的回复，说明
+    // 没有任何人在这之后说过话，没有新内容可回应，直接跳过，避免对着同一段
+    // 历史重新推理一遍、很可能又重复回复一次。
+    if chat_history.last().map(|m| m.role.as_str()) == Some("assistant") {
+        log::debug!("[workspace] Agent「{}」自上次发言后没有新消息，跳过本次唤醒", agent.name);
         set_agent_status(app_handle, agent_id, AgentStatus::Idle).await;
         return Ok(());
     }
@@ -756,7 +875,7 @@ async fn process_agent_wake(
                         format!("调用工具 {} 参数: {}", call.name, call.arguments),
                     )
                     .await;
-                    let result = dispatch_tool_call(app_handle, &workspace, &agent, call).await;
+                    let result = dispatch_tool_call(app_handle, &workspace, &agent, call, cancel).await;
                     log::debug!(
                         "[workspace] 工具 {} 返回: {}",
                         call.name,
@@ -806,13 +925,16 @@ async fn build_chat_history(app_handle: &AppHandle, workspace_id: &str, agent: &
     let db_state = app_handle.state::<DbState>();
     let (messages, agents) = {
         let db = db_state.0.lock().await;
-        let conn = match rusqlite::Connection::open(&db.path) {
+        let conn = match db::open_conn(&db.path) {
             Ok(c) => c,
             Err(_) => return vec![],
         };
         let messages = db::list_recent_messages_for_agent(&conn, workspace_id, &agent.id, MAX_HISTORY_MESSAGES)
             .unwrap_or_default();
-        let agents = db::list_agents(&conn, workspace_id).unwrap_or_default();
+        // Include soft-deleted agents here -- a deleted agent's past messages
+        // are still in this history window and need their sender name
+        // resolved, not shown as a raw id to the model.
+        let agents = db::list_agents_including_deleted(&conn, workspace_id).unwrap_or_default();
         (messages, agents)
     };
 
@@ -822,6 +944,9 @@ async fn build_chat_history(app_handle: &AppHandle, workspace_id: &str, agent: &
         }
         if id == "all" {
             return "所有人".to_string();
+        }
+        if id == "system" {
+            return "系统".to_string();
         }
         agents.iter().find(|a| a.id == id).map(|a| a.name.clone()).unwrap_or_else(|| id.to_string())
     };
@@ -853,6 +978,16 @@ async fn build_chat_history(app_handle: &AppHandle, workspace_id: &str, agent: &
 async fn build_agent_system_prompt(app_handle: &AppHandle, agent: &WorkspaceAgent, latest_query: &str) -> String {
     let mut sections = vec![agent.system_prompt.clone()];
 
+    // 工作记忆：每次唤醒的上下文只由最近 40 条消息重建，工具调用轮次的中间
+    // 结果醒来就丢——scratchpad 是这个空白之外唯一跨唤醒保留的私有存储，靠
+    // workspace_scratchpad 工具自己读写维护，内容原样拼进系统提示词。
+    if !agent.scratchpad.trim().is_empty() {
+        sections.push(format!(
+            "【你的工作备忘（可用 workspace_scratchpad 工具更新）】\n{}",
+            agent.scratchpad
+        ));
+    }
+
     if !agent.active_skill_ids.is_empty() {
         let db_state = app_handle.state::<DbState>();
         let all_skills = {
@@ -877,8 +1012,12 @@ async fn build_agent_system_prompt(app_handle: &AppHandle, agent: &WorkspaceAgen
             let request = RetrievalRequest {
                 kb_id: kb_id.clone(),
                 query: latest_query.to_string(),
-                top_k: 5,
-                retrieval_mode: RetrievalMode::Hybrid,
+                top_k: agent.rag_top_k,
+                retrieval_mode: match agent.rag_retrieval_mode.as_str() {
+                    "vector" => RetrievalMode::Vector,
+                    "keyword" => RetrievalMode::Keyword,
+                    _ => RetrievalMode::Hybrid,
+                },
                 similarity_threshold: 0.0,
                 window_size: 1,
                 reranker_config_id: None,
@@ -942,6 +1081,24 @@ fn workspace_tool_defs(agent: &WorkspaceAgent) -> Vec<MCPTool> {
         },
     ];
 
+    tools.push(MCPTool {
+        server_id: "workspace".to_string(),
+        server_name: "workspace".to_string(),
+        name: "workspace_scratchpad".to_string(),
+        description: "读写你的私人工作备忘。这是唯一跨越「唤醒」持续保留的私有存储（普通对话历史只保留最近\
+            几十条消息，工具调用的中间结果醒来就丢）——用它记录任务清单、已查到的资料、下一步打算做什么，\
+            避免每次醒来都要重新摸索状态。action 为 replace 时整体覆盖，append 时追加一行，clear 清空；\
+            省略 content 直接读出当前内容。"
+            .to_string(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": { "type": "string", "enum": ["read", "replace", "append", "clear"], "description": "read 只读取；replace 整体覆盖；append 追加一行；clear 清空" },
+                "content": { "type": "string", "description": "replace/append 时要写入的内容" }
+            },
+            "required": ["action"]
+        }),
+    });
     tools.push(MCPTool {
         server_id: "workspace".to_string(),
         server_name: "workspace".to_string(),
@@ -1050,6 +1207,7 @@ async fn dispatch_tool_call(
     workspace: &Workspace,
     agent: &WorkspaceAgent,
     call: &PendingToolCall,
+    cancel: &CancellationToken,
 ) -> serde_json::Value {
     match call.name.as_str() {
         "workspace_message" => {
@@ -1068,7 +1226,7 @@ async fn dispatch_tool_call(
             let db_state = app_handle.state::<DbState>();
             let agents = {
                 let db = db_state.0.lock().await;
-                match rusqlite::Connection::open(&db.path) {
+                match db::open_conn(&db.path) {
                     Ok(conn) => db::list_agents(&conn, &workspace.id).unwrap_or_default(),
                     Err(_) => vec![],
                 }
@@ -1093,7 +1251,7 @@ async fn dispatch_tool_call(
             let current_count = {
                 let db_state = app_handle.state::<DbState>();
                 let db = db_state.0.lock().await;
-                rusqlite::Connection::open(&db.path)
+                db::open_conn(&db.path)
                     .ok()
                     .and_then(|conn| db::count_agents(&conn, &workspace.id).ok())
                     .unwrap_or(0)
@@ -1116,10 +1274,12 @@ async fn dispatch_tool_call(
                 mcp_server_ids: vec![],
                 knowledge_base_ids: vec![],
                 active_skill_ids: vec![],
+                rag_top_k: default_rag_top_k(),
+                rag_retrieval_mode: default_rag_retrieval_mode(),
             };
 
             let pending = app_handle.state::<PendingProposals>();
-            propose_agent_creation(app_handle, &pending, &workspace.id, agent, draft).await
+            propose_agent_creation(app_handle, &pending, &workspace.id, agent, draft, cancel).await
         }
         "workspace_sleep" => {
             if agent.role == AgentRole::Main {
@@ -1128,7 +1288,7 @@ async fn dispatch_tool_call(
             let reason = call.arguments.get("reason").and_then(|v| v.as_str()).unwrap_or("未说明").to_string();
 
             set_agent_status(app_handle, &agent.id, AgentStatus::WaitingApproval).await;
-            let approved = request_sleep_approval(app_handle, &workspace.id, agent, &reason).await;
+            let approved = request_sleep_approval(app_handle, &workspace.id, agent, &reason, cancel).await;
             if approved {
                 set_agent_status(app_handle, &agent.id, AgentStatus::Sleeping).await;
                 maybe_trigger_main_agent_review(app_handle, &workspace.id).await;
@@ -1152,6 +1312,8 @@ async fn dispatch_tool_call(
             match sender {
                 Some(tx) => {
                     let _ = tx.send(approved);
+                    let db_state = app_handle.state::<DbState>();
+                    mark_pending_event_resolved(&db_state, &request_id).await;
                     serde_json::json!({ "status": "ok" })
                 }
                 None => serde_json::json!({ "error": format!("休眠请求 {} 不存在或已被处理/超时", request_id) }),
@@ -1163,9 +1325,52 @@ async fn dispatch_tool_call(
                 return serde_json::json!({ "error": "question 不能为空" });
             }
             set_agent_status(app_handle, &agent.id, AgentStatus::WaitingAnswer).await;
-            let answer = request_user_answer(app_handle, &workspace.id, agent, &question).await;
+            let answer = request_user_answer(app_handle, &workspace.id, agent, &question, cancel).await;
             set_agent_status(app_handle, &agent.id, AgentStatus::Running).await;
             serde_json::json!({ "answer": answer })
+        }
+        "workspace_scratchpad" => {
+            let action = call.arguments.get("action").and_then(|v| v.as_str()).unwrap_or("read");
+            let db_state = app_handle.state::<DbState>();
+            let new_content = match action {
+                "clear" => Some(String::new()),
+                "replace" => Some(call.arguments.get("content").and_then(|v| v.as_str()).unwrap_or("").to_string()),
+                "append" => {
+                    let line = call.arguments.get("content").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
+                    if line.is_empty() {
+                        return serde_json::json!({ "error": "append 需要非空 content" });
+                    }
+                    let current = agent.scratchpad.clone();
+                    Some(if current.is_empty() { line } else { format!("{}\n{}", current, line) })
+                }
+                "read" => None,
+                other => return serde_json::json!({ "error": format!("未知 action: {}", other) }),
+            };
+            if let Some(content) = &new_content {
+                let db = db_state.0.lock().await;
+                match db::open_conn(&db.path) {
+                    Ok(conn) => {
+                        if let Err(e) = db::set_scratchpad(&conn, &agent.id, content) {
+                            return serde_json::json!({ "error": format!("写入失败: {}", e) });
+                        }
+                    }
+                    Err(e) => return serde_json::json!({ "error": format!("打开数据库连接失败: {}", e) }),
+                }
+            }
+            let current = match &new_content {
+                Some(c) => c.clone(),
+                None => {
+                    // 读操作现查一次库，而不是用调用这个工具时已经在内存里的
+                    // agent 快照——万一同一次唤醒里工具轮之间有过其他写入
+                    // （目前不会，但语义上"读"就该读最新值）。
+                    let db = db_state.0.lock().await;
+                    match db::open_conn(&db.path) {
+                        Ok(conn) => db::get_scratchpad(&conn, &agent.id).unwrap_or_else(|_| agent.scratchpad.clone()),
+                        Err(_) => agent.scratchpad.clone(),
+                    }
+                }
+            };
+            serde_json::json!({ "scratchpad": current })
         }
         "workspace_log" => {
             let content = call.arguments.get("content").and_then(|v| v.as_str()).unwrap_or("").to_string();
@@ -1268,9 +1473,12 @@ async fn dispatch_tool_call(
             {
                 return serde_json::json!({ "error": "会议协调器启动失败" });
             }
-            match reply_rx.await {
-                Ok(v) => v,
-                Err(_) => serde_json::json!({ "error": "会议已终止" }),
+            tokio::select! {
+                _ = cancel.cancelled() => serde_json::json!({ "error": "工作组已被删除" }),
+                result = reply_rx => match result {
+                    Ok(v) => v,
+                    Err(_) => serde_json::json!({ "error": "会议已终止" }),
+                },
             }
         }
         "workspace_meeting_checkin" => {
@@ -1302,14 +1510,36 @@ async fn dispatch_tool_call(
             {
                 return serde_json::json!({ "error": "会议已结束" });
             }
-            match reply_rx.await {
-                Ok(v) => v,
-                Err(_) => serde_json::json!({ "error": "会议已终止" }),
+            tokio::select! {
+                _ = cancel.cancelled() => serde_json::json!({ "error": "工作组已被删除" }),
+                result = reply_rx => match result {
+                    Ok(v) => v,
+                    Err(_) => serde_json::json!({ "error": "会议已终止" }),
+                },
             }
         }
         _ => {
+            // 权限校验：只允许调用这个 Agent 的 mcp_server_ids 白名单里的服务器
+            // 暴露出来的工具。以前这里直接传 server_id=None，call_mcp_tool 会
+            // 在全部已启用服务器里搜同名工具再执行——只要提示注入诱导模型说出
+            // 一个未授权服务器的工具名就能绕过 Agent 的工具授权范围。
+            if agent.mcp_server_ids.is_empty() {
+                return serde_json::json!({ "error": format!("未知工具 {}，且该 Agent 未被授权使用任何 MCP 服务器", call.name) });
+            }
             let db_state = app_handle.state::<DbState>();
-            match call_mcp_tool(db_state, None, call.name.clone(), call.arguments.clone()).await {
+            let owning_server = match get_all_mcp_tools(db_state.clone()).await {
+                Ok(all_tools) => all_tools
+                    .into_iter()
+                    .find(|t| t.name == call.name && agent.mcp_server_ids.contains(&t.server_id))
+                    .map(|t| t.server_id),
+                Err(e) => {
+                    return serde_json::json!({ "error": format!("获取 MCP 工具列表失败: {}", e) });
+                }
+            };
+            let Some(server_id) = owning_server else {
+                return serde_json::json!({ "error": format!("工具 {} 不存在，或不在该 Agent 被授权使用的 MCP 服务器范围内", call.name) });
+            };
+            match call_mcp_tool(db_state, Some(server_id), call.name.clone(), call.arguments.clone()).await {
                 Ok(v) => v,
                 Err(e) => serde_json::json!({ "error": e.to_string() }),
             }
@@ -1319,14 +1549,18 @@ async fn dispatch_tool_call(
 
 /// Registers a pending proposal, notifies the frontend, and blocks (only
 /// this one tool call's processing -- not the rest of the app) until the
-/// user approves/rejects it via `workspace_resolve_proposal`, or 10 minutes
-/// pass with no response.
+/// user approves/rejects it via `workspace_resolve_proposal`, 10 minutes
+/// pass with no response, or the workspace/agent is deleted out from under
+/// it (`cancel`) -- without racing on `cancel` this wait would otherwise
+/// hold the task open for up to the full 10-minute timeout after deletion,
+/// still writing log entries into a workspace that no longer exists.
 async fn propose_agent_creation(
     app_handle: &AppHandle,
     pending: &PendingProposals,
     workspace_id: &str,
     proposing_agent: &WorkspaceAgent,
     draft: CreateAgentRequest,
+    cancel: &CancellationToken,
 ) -> serde_json::Value {
     let proposal_id = Uuid::new_v4().to_string();
     let (tx, rx) = oneshot::channel();
@@ -1346,6 +1580,17 @@ async fn propose_agent_creation(
         }),
     );
 
+    record_pending_event(
+        app_handle,
+        workspace_id,
+        &proposing_agent.id,
+        &proposing_agent.name,
+        "proposal",
+        serde_json::json!({ "draft": draft, "proposalId": proposal_id }),
+        &proposal_id,
+    )
+    .await;
+
     insert_workspace_log(
         app_handle,
         workspace_id,
@@ -1358,30 +1603,50 @@ async fn propose_agent_creation(
     )
     .await;
 
-    match tokio::time::timeout(Duration::from_secs(PROPOSAL_TIMEOUT_SECS), rx).await {
-        Ok(Ok(ProposalDecision::Approved(final_request))) => {
+    let outcome = tokio::select! {
+        _ = cancel.cancelled() => {
+            pending.0.lock().unwrap().remove(&proposal_id);
+            None
+        }
+        result = tokio::time::timeout(Duration::from_secs(PROPOSAL_TIMEOUT_SECS), rx) => Some(result),
+    };
+
+    let response = match outcome {
+        None => {
+            mark_pending_event_resolved_via_handle(app_handle, &proposal_id).await;
+            return serde_json::json!({ "status": "cancelled", "message": "工作组已被删除" });
+        }
+        Some(Ok(Ok(ProposalDecision::Approved(final_request)))) => {
             let agent_handles = app_handle.state::<WorkspaceState>().0.clone();
             match spawn_agent_internal(app_handle, agent_handles, *final_request).await {
                 Ok(agent) => serde_json::json!({ "status": "approved", "agentId": agent.id, "name": agent.name }),
                 Err(e) => serde_json::json!({ "status": "error", "message": e.to_string() }),
             }
         }
-        Ok(Ok(ProposalDecision::Rejected)) => serde_json::json!({ "status": "rejected_by_user" }),
-        Ok(Err(_)) => serde_json::json!({ "status": "rejected_by_user" }),
-        Err(_) => {
+        Some(Ok(Ok(ProposalDecision::Rejected))) => serde_json::json!({ "status": "rejected_by_user" }),
+        Some(Ok(Err(_))) => serde_json::json!({ "status": "rejected_by_user" }),
+        Some(Err(_)) => {
             pending.0.lock().unwrap().remove(&proposal_id);
             serde_json::json!({ "status": "timed_out", "message": "用户在 10 分钟内没有响应，提议已取消" })
         }
-    }
+    };
+    mark_pending_event_resolved_via_handle(app_handle, &proposal_id).await;
+    response
 }
 
 /// Registers a pending sleep request, tells the main agent about it (which
 /// also wakes it), and blocks until either the main agent calls
-/// `workspace_approve_sleep`/`workspace_reject_sleep` or the user overrides
-/// via `workspace_resolve_sleep_request`. Defaults to *not* approved if 10
-/// minutes pass with no response -- staying awake is the safer default than
-/// silently letting an agent go quiet.
-async fn request_sleep_approval(app_handle: &AppHandle, workspace_id: &str, agent: &WorkspaceAgent, reason: &str) -> bool {
+/// `workspace_approve_sleep`/`workspace_reject_sleep`, the user overrides
+/// via `workspace_resolve_sleep_request`, 10 minutes pass with no response
+/// (staying awake is the safer default than silently letting an agent go
+/// quiet), or `cancel` fires because the workspace/agent was deleted.
+async fn request_sleep_approval(
+    app_handle: &AppHandle,
+    workspace_id: &str,
+    agent: &WorkspaceAgent,
+    reason: &str,
+    cancel: &CancellationToken,
+) -> bool {
     let request_id = Uuid::new_v4().to_string();
     let (tx, rx) = oneshot::channel();
     {
@@ -1396,6 +1661,17 @@ async fn request_sleep_approval(app_handle: &AppHandle, workspace_id: &str, agen
             "agentId": agent.id, "agentName": agent.name, "reason": reason,
         }),
     );
+
+    record_pending_event(
+        app_handle,
+        workspace_id,
+        &agent.id,
+        &agent.name,
+        "sleep",
+        serde_json::json!({ "reason": reason, "requestId": request_id }),
+        &request_id,
+    )
+    .await;
 
     if let Some(main_id) = find_main_agent_id(app_handle, workspace_id).await {
         send_workspace_message(
@@ -1414,20 +1690,41 @@ async fn request_sleep_approval(app_handle: &AppHandle, workspace_id: &str, agen
     insert_workspace_log(app_handle, workspace_id, Some(agent.id.clone()), "sleep_request", format!("{} 申请休眠：{}", agent.name, reason))
         .await;
 
-    match tokio::time::timeout(Duration::from_secs(PROPOSAL_TIMEOUT_SECS), rx).await {
-        Ok(Ok(approved)) => approved,
-        Ok(Err(_)) => false,
-        Err(_) => {
+    let outcome = tokio::select! {
+        _ = cancel.cancelled() => {
+            app_handle.state::<PendingSleepRequests>().0.lock().unwrap().remove(&request_id);
+            None
+        }
+        result = tokio::time::timeout(Duration::from_secs(PROPOSAL_TIMEOUT_SECS), rx) => Some(result),
+    };
+
+    let approved = match outcome {
+        None => {
+            mark_pending_event_resolved_via_handle(app_handle, &request_id).await;
+            return false;
+        }
+        Some(Ok(Ok(approved))) => approved,
+        Some(Ok(Err(_))) => false,
+        Some(Err(_)) => {
             app_handle.state::<PendingSleepRequests>().0.lock().unwrap().remove(&request_id);
             false
         }
-    }
+    };
+    mark_pending_event_resolved_via_handle(app_handle, &request_id).await;
+    approved
 }
 
 /// Registers a pending question, notifies the frontend to pop up an answer
-/// card, and blocks until the user answers via `workspace_resolve_question`
-/// or 10 minutes pass with no response.
-async fn request_user_answer(app_handle: &AppHandle, workspace_id: &str, agent: &WorkspaceAgent, question: &str) -> String {
+/// card, and blocks until the user answers via `workspace_resolve_question`,
+/// 10 minutes pass with no response, or `cancel` fires because the
+/// workspace/agent was deleted.
+async fn request_user_answer(
+    app_handle: &AppHandle,
+    workspace_id: &str,
+    agent: &WorkspaceAgent,
+    question: &str,
+    cancel: &CancellationToken,
+) -> String {
     let question_id = Uuid::new_v4().to_string();
     let (tx, rx) = oneshot::channel();
     {
@@ -1442,14 +1739,38 @@ async fn request_user_answer(app_handle: &AppHandle, workspace_id: &str, agent: 
             "agentId": agent.id, "agentName": agent.name, "question": question,
         }),
     );
+    record_pending_event(
+        app_handle,
+        workspace_id,
+        &agent.id,
+        &agent.name,
+        "question",
+        serde_json::json!({ "question": question, "questionId": question_id }),
+        &question_id,
+    )
+    .await;
     insert_workspace_log(app_handle, workspace_id, Some(agent.id.clone()), "question", format!("{} 提问：{}", agent.name, question)).await;
 
-    match tokio::time::timeout(Duration::from_secs(PROPOSAL_TIMEOUT_SECS), rx).await {
-        Ok(Ok(answer)) => answer,
-        Ok(Err(_)) => "（用户没有回答）".to_string(),
-        Err(_) => {
+    let outcome = tokio::select! {
+        _ = cancel.cancelled() => {
+            app_handle.state::<PendingQuestions>().0.lock().unwrap().remove(&question_id);
+            None
+        }
+        result = tokio::time::timeout(Duration::from_secs(PROPOSAL_TIMEOUT_SECS), rx) => Some(result),
+    };
+
+    let answer = match outcome {
+        None => {
+            mark_pending_event_resolved_via_handle(app_handle, &question_id).await;
+            return "（工作组已被删除）".to_string();
+        }
+        Some(Ok(Ok(answer))) => answer,
+        Some(Ok(Err(_))) => "（用户没有回答）".to_string(),
+        Some(Err(_)) => {
             app_handle.state::<PendingQuestions>().0.lock().unwrap().remove(&question_id);
             "（用户在限定时间内没有回答）".to_string()
         }
-    }
+    };
+    mark_pending_event_resolved_via_handle(app_handle, &question_id).await;
+    answer
 }

--- a/src-tauri/src/workspace/db.rs
+++ b/src-tauri/src/workspace/db.rs
@@ -5,10 +5,21 @@
 use super::types::*;
 use rusqlite::Connection;
 
-/// Create the Workspace tables if they don't already exist. Meeting-specific
-/// tables are deliberately not here yet -- the meeting mechanism (Phase 3)
-/// is still basic round-robin only and doesn't need persisted state beyond
-/// `workspace_logs`.
+/// Opens a connection with a busy-timeout set, so a write that lands while
+/// another connection briefly holds the write lock retries for up to 5s
+/// instead of failing immediately with `SQLITE_BUSY` -- every business
+/// operation in this module opens its own short-lived connection (see
+/// `delete_workspace`'s doc comment), so concurrent writes from two agents'
+/// loops firing at once is a real, not theoretical, scenario.
+pub fn open_conn(path: &str) -> Result<Connection, WorkspaceError> {
+    let conn = Connection::open(path)?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))?;
+    Ok(conn)
+}
+
+/// Create the Workspace tables if they don't already exist, and additively
+/// migrate older installs (`ALTER TABLE ... ADD COLUMN`, guarded by checking
+/// `PRAGMA table_info` first) up to the current schema.
 pub fn init_workspace_tables(conn: &Connection) -> Result<(), rusqlite::Error> {
     conn.execute(
         r#"
@@ -76,6 +87,22 @@ pub fn init_workspace_tables(conn: &Connection) -> Result<(), rusqlite::Error> {
     )?;
 
     conn.execute(
+        r#"
+        CREATE TABLE IF NOT EXISTS workspace_pending_events (
+            id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            agent_id TEXT NOT NULL,
+            agent_name TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            resolved_at INTEGER
+        )
+        "#,
+        [],
+    )?;
+
+    conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_workspace_agents_workspace ON workspace_agents(workspace_id)",
         [],
     )?;
@@ -91,6 +118,32 @@ pub fn init_workspace_tables(conn: &Connection) -> Result<(), rusqlite::Error> {
         "CREATE INDEX IF NOT EXISTS idx_workspace_logs_workspace ON workspace_logs(workspace_id, created_at)",
         [],
     )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workspace_pending_events_open ON workspace_pending_events(workspace_id, resolved_at)",
+        [],
+    )?;
+
+    // Additive migrations for installs created before this column set existed.
+    let agent_columns: Vec<String> = conn
+        .prepare("PRAGMA table_info(workspace_agents)")?
+        .query_map([], |row| row.get(1))?
+        .filter_map(|r| r.ok())
+        .collect();
+    if !agent_columns.contains(&"deleted_at".to_string()) {
+        conn.execute("ALTER TABLE workspace_agents ADD COLUMN deleted_at INTEGER", [])?;
+    }
+    if !agent_columns.contains(&"rag_top_k".to_string()) {
+        conn.execute("ALTER TABLE workspace_agents ADD COLUMN rag_top_k INTEGER NOT NULL DEFAULT 5", [])?;
+    }
+    if !agent_columns.contains(&"rag_retrieval_mode".to_string()) {
+        conn.execute(
+            "ALTER TABLE workspace_agents ADD COLUMN rag_retrieval_mode TEXT NOT NULL DEFAULT 'hybrid'",
+            [],
+        )?;
+    }
+    if !agent_columns.contains(&"scratchpad".to_string()) {
+        conn.execute("ALTER TABLE workspace_agents ADD COLUMN scratchpad TEXT NOT NULL DEFAULT ''", [])?;
+    }
 
     log::info!("Workspace SQLite tables initialized");
     Ok(())
@@ -148,14 +201,17 @@ pub fn get_workspace(conn: &Connection, id: &str) -> Result<Option<Workspace>, W
 pub fn delete_workspace(conn: &Connection, id: &str) -> Result<(), WorkspaceError> {
     conn.execute("DELETE FROM workspace_messages WHERE workspace_id = ?1", [id])?;
     conn.execute("DELETE FROM workspace_logs WHERE workspace_id = ?1", [id])?;
+    conn.execute("DELETE FROM workspace_pending_events WHERE workspace_id = ?1", [id])?;
     conn.execute("DELETE FROM workspace_agents WHERE workspace_id = ?1", [id])?;
     conn.execute("DELETE FROM workspaces WHERE id = ?1", [id])?;
     Ok(())
 }
 
+/// Active (non-soft-deleted) agent count, used for the `max_agents` safety
+/// cap -- a deleted agent shouldn't hold a seat open.
 pub fn count_agents(conn: &Connection, workspace_id: &str) -> Result<i64, WorkspaceError> {
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM workspace_agents WHERE workspace_id = ?1",
+        "SELECT COUNT(*) FROM workspace_agents WHERE workspace_id = ?1 AND deleted_at IS NULL",
         [workspace_id],
         |row| row.get(0),
     )?;
@@ -182,20 +238,26 @@ fn row_to_agent(row: &rusqlite::Row) -> rusqlite::Result<WorkspaceAgent> {
         knowledge_base_ids: serde_json::from_str(&knowledge_base_ids).unwrap_or_default(),
         active_skill_ids: serde_json::from_str(&active_skill_ids).unwrap_or_default(),
         status: AgentStatus::from_str(&status),
+        rag_top_k: row.get(15)?,
+        rag_retrieval_mode: row.get(16)?,
+        scratchpad: row.get(17)?,
+        deleted_at: row.get(18)?,
         created_at: row.get(13)?,
         updated_at: row.get(14)?,
     })
 }
 
 const AGENT_SELECT_COLUMNS: &str = "id, workspace_id, name, role, provider, model, base_url, api_config_id, \
-     mcp_server_ids, knowledge_base_ids, active_skill_ids, status, system_prompt, created_at, updated_at";
+     mcp_server_ids, knowledge_base_ids, active_skill_ids, status, system_prompt, created_at, updated_at, \
+     rag_top_k, rag_retrieval_mode, scratchpad, deleted_at";
 
 pub fn insert_agent(conn: &Connection, agent: &WorkspaceAgent) -> Result<(), WorkspaceError> {
     conn.execute(
         "INSERT INTO workspace_agents
          (id, workspace_id, name, role, provider, model, base_url, api_config_id,
-          system_prompt, mcp_server_ids, knowledge_base_ids, active_skill_ids, status, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+          system_prompt, mcp_server_ids, knowledge_base_ids, active_skill_ids, status, created_at, updated_at,
+          rag_top_k, rag_retrieval_mode, scratchpad, deleted_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
         rusqlite::params![
             agent.id,
             agent.workspace_id,
@@ -212,11 +274,19 @@ pub fn insert_agent(conn: &Connection, agent: &WorkspaceAgent) -> Result<(), Wor
             agent.status.as_str(),
             agent.created_at,
             agent.updated_at,
+            agent.rag_top_k,
+            agent.rag_retrieval_mode,
+            agent.scratchpad,
+            agent.deleted_at,
         ],
     )?;
     Ok(())
 }
 
+/// Looks up an agent by id regardless of soft-delete status -- used both for
+/// the live agent-loop path (which only ever holds ids of active agents
+/// anyway) and to backfill display names for historical messages/logs sent
+/// by an agent that has since been deleted.
 pub fn get_agent(conn: &Connection, id: &str) -> Result<Option<WorkspaceAgent>, WorkspaceError> {
     let sql = format!("SELECT {} FROM workspace_agents WHERE id = ?1", AGENT_SELECT_COLUMNS);
     let result = conn.query_row(&sql, [id], row_to_agent);
@@ -227,7 +297,24 @@ pub fn get_agent(conn: &Connection, id: &str) -> Result<Option<WorkspaceAgent>, 
     }
 }
 
+/// Active agents only (excludes soft-deleted) -- what every existing caller
+/// (agent roster, meeting participants, max-agents count, main-agent lookup)
+/// actually wants. Use `get_agent` directly when a deleted agent's row still
+/// needs to be resolvable (e.g. historical message sender names).
 pub fn list_agents(conn: &Connection, workspace_id: &str) -> Result<Vec<WorkspaceAgent>, WorkspaceError> {
+    let sql = format!(
+        "SELECT {} FROM workspace_agents WHERE workspace_id = ?1 AND deleted_at IS NULL ORDER BY created_at ASC",
+        AGENT_SELECT_COLUMNS
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([workspace_id], row_to_agent)?;
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
+/// All agents including soft-deleted ones -- used only where a deleted
+/// agent's name still needs to resolve (rendering historical messages/logs
+/// that reference it). Everything else should use `list_agents`.
+pub fn list_agents_including_deleted(conn: &Connection, workspace_id: &str) -> Result<Vec<WorkspaceAgent>, WorkspaceError> {
     let sql = format!(
         "SELECT {} FROM workspace_agents WHERE workspace_id = ?1 ORDER BY created_at ASC",
         AGENT_SELECT_COLUMNS
@@ -245,8 +332,67 @@ pub fn update_agent_status(conn: &Connection, id: &str, status: AgentStatus) -> 
     Ok(())
 }
 
+/// Applies user edits to an existing agent's config. Deliberately doesn't
+/// touch `status` -- the live loop reloads the row fresh every wake, so a
+/// plain field update takes effect on the agent's next turn without needing
+/// to restart its background task.
+pub fn update_agent(conn: &Connection, req: &UpdateAgentRequest) -> Result<(), WorkspaceError> {
+    let rows = conn.execute(
+        "UPDATE workspace_agents SET name = ?1, provider = ?2, model = ?3, base_url = ?4, api_config_id = ?5, \
+         system_prompt = ?6, mcp_server_ids = ?7, knowledge_base_ids = ?8, active_skill_ids = ?9, \
+         rag_top_k = ?10, rag_retrieval_mode = ?11, updated_at = ?12 \
+         WHERE id = ?13 AND deleted_at IS NULL",
+        rusqlite::params![
+            req.name,
+            req.provider,
+            req.model,
+            req.base_url,
+            req.api_config_id,
+            req.system_prompt,
+            serde_json::to_string(&req.mcp_server_ids).unwrap_or_else(|_| "[]".to_string()),
+            serde_json::to_string(&req.knowledge_base_ids).unwrap_or_else(|_| "[]".to_string()),
+            serde_json::to_string(&req.active_skill_ids).unwrap_or_else(|_| "[]".to_string()),
+            req.rag_top_k,
+            req.rag_retrieval_mode,
+            chrono::Utc::now().timestamp_millis(),
+            req.id,
+        ],
+    )?;
+    if rows == 0 {
+        return Err(WorkspaceError::AgentNotFound(req.id.clone()));
+    }
+    Ok(())
+}
+
+pub fn get_scratchpad(conn: &Connection, agent_id: &str) -> Result<String, WorkspaceError> {
+    let result = conn.query_row(
+        "SELECT scratchpad FROM workspace_agents WHERE id = ?1",
+        [agent_id],
+        |row| row.get(0),
+    );
+    match result {
+        Ok(s) => Ok(s),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(String::new()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn set_scratchpad(conn: &Connection, agent_id: &str, content: &str) -> Result<(), WorkspaceError> {
+    conn.execute(
+        "UPDATE workspace_agents SET scratchpad = ?1 WHERE id = ?2",
+        rusqlite::params![content, agent_id],
+    )?;
+    Ok(())
+}
+
+/// Soft delete: keeps the row (with `deleted_at` set) so historical
+/// messages/logs referencing this agent id can still resolve its name,
+/// instead of falling back to a raw UUID in the timeline.
 pub fn delete_agent(conn: &Connection, id: &str) -> Result<(), WorkspaceError> {
-    conn.execute("DELETE FROM workspace_agents WHERE id = ?1", [id])?;
+    conn.execute(
+        "UPDATE workspace_agents SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2",
+        rusqlite::params![chrono::Utc::now().timestamp_millis(), id],
+    )?;
     Ok(())
 }
 
@@ -336,6 +482,62 @@ pub fn list_logs(conn: &Connection, workspace_id: &str, limit: i64) -> Result<Ve
     Ok(logs)
 }
 
+fn row_to_pending_event(row: &rusqlite::Row) -> rusqlite::Result<WorkspacePendingEvent> {
+    let payload: String = row.get(5)?;
+    Ok(WorkspacePendingEvent {
+        id: row.get(0)?,
+        workspace_id: row.get(1)?,
+        agent_id: row.get(2)?,
+        agent_name: row.get(3)?,
+        kind: row.get(4)?,
+        payload: serde_json::from_str(&payload).unwrap_or(serde_json::Value::Null),
+        created_at: row.get(6)?,
+        resolved_at: row.get(7)?,
+    })
+}
+
+/// Records a proposal/sleep-request/question the moment it's raised, so it
+/// survives a restart or a user who wasn't looking at this page when the
+/// one-shot frontend event fired. `id` must match the id used to resolve it
+/// (`proposal_id`/`request_id`/`question_id`) so `resolve_pending_event` can
+/// find it again.
+pub fn insert_pending_event(conn: &Connection, event: &WorkspacePendingEvent) -> Result<(), WorkspaceError> {
+    conn.execute(
+        "INSERT INTO workspace_pending_events (id, workspace_id, agent_id, agent_name, kind, payload, created_at, resolved_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL)",
+        rusqlite::params![
+            event.id,
+            event.workspace_id,
+            event.agent_id,
+            event.agent_name,
+            event.kind,
+            serde_json::to_string(&event.payload).unwrap_or_else(|_| "null".to_string()),
+            event.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn resolve_pending_event(conn: &Connection, id: &str) -> Result<(), WorkspaceError> {
+    conn.execute(
+        "UPDATE workspace_pending_events SET resolved_at = ?1 WHERE id = ?2",
+        rusqlite::params![chrono::Utc::now().timestamp_millis(), id],
+    )?;
+    Ok(())
+}
+
+/// Everything still awaiting a human decision in this workspace, oldest
+/// first -- what the frontend fetches on selecting a workspace to backfill
+/// anything it missed while the page (or the app) wasn't open.
+pub fn list_unresolved_pending_events(conn: &Connection, workspace_id: &str) -> Result<Vec<WorkspacePendingEvent>, WorkspaceError> {
+    let mut stmt = conn.prepare(
+        "SELECT id, workspace_id, agent_id, agent_name, kind, payload, created_at, resolved_at
+         FROM workspace_pending_events WHERE workspace_id = ?1 AND resolved_at IS NULL ORDER BY created_at ASC",
+    )?;
+    let rows = stmt.query_map([workspace_id], row_to_pending_event)?;
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -361,6 +563,10 @@ mod tests {
             knowledge_base_ids: vec![],
             active_skill_ids: vec![],
             status: AgentStatus::Idle,
+            rag_top_k: 5,
+            rag_retrieval_mode: "hybrid".to_string(),
+            scratchpad: String::new(),
+            deleted_at: None,
             created_at: 1000,
             updated_at: 1000,
         }
@@ -500,5 +706,134 @@ mod tests {
         assert!(list_agents(&conn, "ws-1").unwrap().is_empty());
         assert!(list_messages(&conn, "ws-1", 10).unwrap().is_empty());
         assert!(list_logs(&conn, "ws-1", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn deleted_agent_is_excluded_from_list_and_count_but_still_resolvable_by_id() {
+        let conn = setup();
+        insert_workspace(
+            &conn,
+            &Workspace { id: "ws-1".into(), name: "WS".into(), description: "".into(), max_agents: 5, created_at: 0, updated_at: 0 },
+        )
+        .unwrap();
+        let agent = sample_agent("ws-1", AgentRole::Sub, "A");
+        insert_agent(&conn, &agent).unwrap();
+        assert_eq!(count_agents(&conn, "ws-1").unwrap(), 1);
+
+        delete_agent(&conn, &agent.id).unwrap();
+
+        assert_eq!(count_agents(&conn, "ws-1").unwrap(), 0);
+        assert!(list_agents(&conn, "ws-1").unwrap().is_empty());
+        // Still resolvable by id -- historical messages/logs need the name.
+        let fetched = get_agent(&conn, &agent.id).unwrap().expect("soft-deleted agent should still be gettable by id");
+        assert!(fetched.deleted_at.is_some());
+        assert_eq!(fetched.name, "A");
+    }
+
+    #[test]
+    fn update_agent_persists_edits_without_touching_status() {
+        let conn = setup();
+        insert_workspace(
+            &conn,
+            &Workspace { id: "ws-1".into(), name: "WS".into(), description: "".into(), max_agents: 5, created_at: 0, updated_at: 0 },
+        )
+        .unwrap();
+        let agent = sample_agent("ws-1", AgentRole::Sub, "A");
+        insert_agent(&conn, &agent).unwrap();
+        update_agent_status(&conn, &agent.id, AgentStatus::Running).unwrap();
+
+        update_agent(
+            &conn,
+            &UpdateAgentRequest {
+                id: agent.id.clone(),
+                name: "A-renamed".to_string(),
+                provider: "deepseek".to_string(),
+                model: "deepseek-v4".to_string(),
+                base_url: "https://api.deepseek.com/v1".to_string(),
+                api_config_id: "cfg-2".to_string(),
+                system_prompt: "be terse".to_string(),
+                mcp_server_ids: vec![],
+                knowledge_base_ids: vec!["kb-1".to_string()],
+                active_skill_ids: vec![],
+                rag_top_k: 8,
+                rag_retrieval_mode: "vector".to_string(),
+            },
+        )
+        .unwrap();
+
+        let fetched = get_agent(&conn, &agent.id).unwrap().unwrap();
+        assert_eq!(fetched.name, "A-renamed");
+        assert_eq!(fetched.provider, "deepseek");
+        assert_eq!(fetched.rag_top_k, 8);
+        assert_eq!(fetched.rag_retrieval_mode, "vector");
+        assert_eq!(fetched.knowledge_base_ids, vec!["kb-1".to_string()]);
+        // Status untouched by an edit -- the live loop reloads config, not status.
+        assert_eq!(fetched.status, AgentStatus::Running);
+
+        assert!(matches!(
+            update_agent(
+                &conn,
+                &UpdateAgentRequest {
+                    id: "missing".to_string(),
+                    name: "x".to_string(),
+                    provider: "x".to_string(),
+                    model: "x".to_string(),
+                    base_url: "".to_string(),
+                    api_config_id: "".to_string(),
+                    system_prompt: "".to_string(),
+                    mcp_server_ids: vec![],
+                    knowledge_base_ids: vec![],
+                    active_skill_ids: vec![],
+                    rag_top_k: 5,
+                    rag_retrieval_mode: "hybrid".to_string(),
+                },
+            ),
+            Err(WorkspaceError::AgentNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn scratchpad_round_trips_and_defaults_to_empty() {
+        let conn = setup();
+        insert_workspace(
+            &conn,
+            &Workspace { id: "ws-1".into(), name: "WS".into(), description: "".into(), max_agents: 5, created_at: 0, updated_at: 0 },
+        )
+        .unwrap();
+        let agent = sample_agent("ws-1", AgentRole::Sub, "A");
+        insert_agent(&conn, &agent).unwrap();
+
+        assert_eq!(get_scratchpad(&conn, &agent.id).unwrap(), "");
+        set_scratchpad(&conn, &agent.id, "已联系客户，等回复").unwrap();
+        assert_eq!(get_scratchpad(&conn, &agent.id).unwrap(), "已联系客户，等回复");
+    }
+
+    #[test]
+    fn pending_events_round_trip_and_resolve_excludes_from_unresolved_list() {
+        let conn = setup();
+        insert_workspace(
+            &conn,
+            &Workspace { id: "ws-1".into(), name: "WS".into(), description: "".into(), max_agents: 5, created_at: 0, updated_at: 0 },
+        )
+        .unwrap();
+
+        let event = WorkspacePendingEvent {
+            id: "evt-1".to_string(),
+            workspace_id: "ws-1".to_string(),
+            agent_id: "agent-a".to_string(),
+            agent_name: "A".to_string(),
+            kind: "sleep".to_string(),
+            payload: serde_json::json!({ "reason": "done for now" }),
+            created_at: 100,
+            resolved_at: None,
+        };
+        insert_pending_event(&conn, &event).unwrap();
+
+        let unresolved = list_unresolved_pending_events(&conn, "ws-1").unwrap();
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0].payload["reason"], "done for now");
+
+        resolve_pending_event(&conn, "evt-1").unwrap();
+        assert!(list_unresolved_pending_events(&conn, "ws-1").unwrap().is_empty());
     }
 }

--- a/src-tauri/src/workspace/types.rs
+++ b/src-tauri/src/workspace/types.rs
@@ -143,6 +143,18 @@ pub struct WorkspaceAgent {
     pub knowledge_base_ids: Vec<String>,
     pub active_skill_ids: Vec<String>,
     pub status: AgentStatus,
+    /// RAG 检索的 top_k，之前在 build_agent_system_prompt 里硬编码为 5。
+    pub rag_top_k: i32,
+    /// RAG 检索模式，之前硬编码为 "hybrid"；取值 "vector"/"keyword"/"hybrid"。
+    pub rag_retrieval_mode: String,
+    /// 跨唤醒保留的私有备忘（由 workspace_scratchpad 工具读写），每次唤醒都会
+    /// 拼进系统提示词，弥补"每次醒来只记得群聊记录"的工作记忆缺失。
+    #[serde(default)]
+    pub scratchpad: String,
+    /// 软删除时间戳；非 None 表示这个 Agent 已被用户删除，但消息/日志历史里
+    /// 引用它的记录仍需要能正确显示名字，所以不做物理删除。
+    #[serde(default)]
+    pub deleted_at: Option<i64>,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -204,6 +216,69 @@ pub struct CreateAgentRequest {
     pub knowledge_base_ids: Vec<String>,
     #[serde(default)]
     pub active_skill_ids: Vec<String>,
+    #[serde(default = "default_rag_top_k")]
+    pub rag_top_k: i32,
+    #[serde(default = "default_rag_retrieval_mode")]
+    pub rag_retrieval_mode: String,
+}
+
+pub fn default_rag_top_k() -> i32 {
+    5
+}
+
+pub fn default_rag_retrieval_mode() -> String {
+    "hybrid".to_string()
+}
+
+/// Editable fields for an existing agent (`workspace_update_agent`). Deliberately
+/// omits `role`/`workspace_id` -- switching a running agent between main/sub
+/// makes its already-issued tool-availability assumptions stale, and moving it
+/// to another workspace has no defined semantics; delete-and-recreate covers
+/// those rare cases. Everything else here is safe to change live because
+/// `process_agent_wake` reloads the agent's row fresh from the DB every wake.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateAgentRequest {
+    pub id: String,
+    pub name: String,
+    pub provider: String,
+    pub model: String,
+    pub base_url: String,
+    pub api_config_id: String,
+    #[serde(default)]
+    pub system_prompt: String,
+    #[serde(default)]
+    pub mcp_server_ids: Vec<String>,
+    #[serde(default)]
+    pub knowledge_base_ids: Vec<String>,
+    #[serde(default)]
+    pub active_skill_ids: Vec<String>,
+    #[serde(default = "default_rag_top_k")]
+    pub rag_top_k: i32,
+    #[serde(default = "default_rag_retrieval_mode")]
+    pub rag_retrieval_mode: String,
+}
+
+/// A `workspace_create_agent` proposal / `workspace_sleep` request /
+/// `workspace_asks` question that's waiting on a human decision, persisted so
+/// it survives an app restart or a user simply not having the page open when
+/// it fired (previously these lived only as in-memory oneshot channels plus a
+/// fire-and-forget frontend event -- miss the event and the request was gone
+/// for good even though the agent was still blocked waiting on it).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspacePendingEvent {
+    pub id: String,
+    pub workspace_id: String,
+    pub agent_id: String,
+    pub agent_name: String,
+    /// "proposal" | "sleep" | "question"
+    pub kind: String,
+    /// Type-specific fields as JSON: proposal carries `draft`; sleep carries
+    /// `reason`; question carries `question`.
+    pub payload: serde_json::Value,
+    pub created_at: i64,
+    pub resolved_at: Option<i64>,
 }
 
 pub const DEFAULT_MAX_AGENTS: i32 = 5;

--- a/src-tauri/src/workspace_smoke_test.rs
+++ b/src-tauri/src/workspace_smoke_test.rs
@@ -56,6 +56,8 @@ pub async fn run(app_handle: AppHandle) {
             mcp_server_ids: vec![],
             knowledge_base_ids: vec![],
             active_skill_ids: vec![],
+            rag_top_k: 5,
+            rag_retrieval_mode: "hybrid".to_string(),
         },
         app_handle.clone(),
         workspace_state.clone(),
@@ -84,6 +86,8 @@ pub async fn run(app_handle: AppHandle) {
             mcp_server_ids: vec![],
             knowledge_base_ids: vec![],
             active_skill_ids: vec![],
+            rag_top_k: 5,
+            rag_retrieval_mode: "hybrid".to_string(),
         },
         app_handle.clone(),
         workspace_state.clone(),
@@ -136,7 +140,7 @@ pub async fn run(app_handle: AppHandle) {
         }
     }
 
-    match crate::workspace::commands::workspace_list_messages(workspace.id.clone(), db_state.clone()).await {
+    match crate::workspace::commands::workspace_list_messages(workspace.id.clone(), None, db_state.clone()).await {
         Ok(messages) => {
             log::info!("[smoke_test] ===== 消息记录 ({} 条) =====", messages.len());
             for m in &messages {
@@ -146,7 +150,7 @@ pub async fn run(app_handle: AppHandle) {
         Err(e) => log::error!("[smoke_test] 查询消息失败: {}", e),
     }
 
-    match crate::workspace::commands::workspace_list_logs(workspace.id.clone(), db_state.clone()).await {
+    match crate::workspace::commands::workspace_list_logs(workspace.id.clone(), None, db_state.clone()).await {
         Ok(logs) => {
             log::info!("[smoke_test] ===== 日志记录 ({} 条) =====", logs.len());
             for l in &logs {
@@ -169,10 +173,12 @@ pub async fn run(app_handle: AppHandle) {
             let Some(question_id) = value.get("questionId").and_then(|v| v.as_str()) else { return };
             log::info!("[smoke_test] 监听到提问事件，自动代用户回答: {}", question_id);
             let pending = handle.state::<PendingQuestions>();
+            let db_state = handle.state::<DbState>();
             if let Err(e) = crate::workspace::commands::workspace_resolve_question(
                 question_id.to_string(),
                 "可以，辛苦了，批准休息。".to_string(),
                 pending,
+                db_state,
             )
             .await
             {
@@ -196,7 +202,8 @@ pub async fn run(app_handle: AppHandle) {
             log::info!("[smoke_test] 监听到休眠申请事件: {}，给主 Agent 30s 自行批准的机会", request_id);
             tokio::time::sleep(Duration::from_secs(30)).await;
             let pending = handle.state::<PendingSleepRequests>();
-            match crate::workspace::commands::workspace_resolve_sleep_request(request_id.clone(), true, pending).await {
+            let db_state = handle.state::<DbState>();
+            match crate::workspace::commands::workspace_resolve_sleep_request(request_id.clone(), true, pending, db_state).await {
                 Ok(()) => log::info!("[smoke_test] 主 Agent 30s 内没批准，已通过用户代为批准覆盖: {}", request_id),
                 Err(_) => log::info!("[smoke_test] 主 Agent 已经自己处理过这个休眠申请: {}", request_id),
             }
@@ -259,7 +266,7 @@ pub async fn run(app_handle: AppHandle) {
         }
     }
 
-    match crate::workspace::commands::workspace_list_messages(workspace.id.clone(), db_state.clone()).await {
+    match crate::workspace::commands::workspace_list_messages(workspace.id.clone(), None, db_state.clone()).await {
         Ok(messages) => {
             log::info!("[smoke_test] ===== Phase 2 后完整消息记录 ({} 条) =====", messages.len());
             for m in &messages {
@@ -269,7 +276,7 @@ pub async fn run(app_handle: AppHandle) {
         Err(e) => log::error!("[smoke_test] 查询消息失败: {}", e),
     }
 
-    match crate::workspace::commands::workspace_list_logs(workspace.id.clone(), db_state.clone()).await {
+    match crate::workspace::commands::workspace_list_logs(workspace.id.clone(), None, db_state.clone()).await {
         Ok(logs) => {
             log::info!("[smoke_test] ===== Phase 2 后完整日志记录 ({} 条) =====", logs.len());
             for l in &logs {
@@ -315,6 +322,8 @@ pub async fn run(app_handle: AppHandle) {
             mcp_server_ids: vec![],
             knowledge_base_ids: vec![],
             active_skill_ids: vec![],
+            rag_top_k: 5,
+            rag_retrieval_mode: "hybrid".to_string(),
         },
         app_handle.clone(),
         workspace_state.clone(),
@@ -344,6 +353,8 @@ pub async fn run(app_handle: AppHandle) {
             mcp_server_ids: vec![],
             knowledge_base_ids: vec![],
             active_skill_ids: vec![],
+            rag_top_k: 5,
+            rag_retrieval_mode: "hybrid".to_string(),
         },
         app_handle.clone(),
         workspace_state.clone(),
@@ -402,7 +413,7 @@ pub async fn run(app_handle: AppHandle) {
         }
     }
 
-    match crate::workspace::commands::workspace_list_messages(meeting_ws.id.clone(), db_state.clone()).await {
+    match crate::workspace::commands::workspace_list_messages(meeting_ws.id.clone(), None, db_state.clone()).await {
         Ok(messages) => {
             log::info!("[smoke_test] ===== Phase 3 消息记录 ({} 条) =====", messages.len());
             for m in &messages {
@@ -412,7 +423,7 @@ pub async fn run(app_handle: AppHandle) {
         Err(e) => log::error!("[smoke_test] Phase 3 查询消息失败: {}", e),
     }
 
-    match crate::workspace::commands::workspace_list_logs(meeting_ws.id.clone(), db_state.clone()).await {
+    match crate::workspace::commands::workspace_list_logs(meeting_ws.id.clone(), None, db_state.clone()).await {
         Ok(logs) => {
             log::info!("[smoke_test] ===== Phase 3 日志记录 ({} 条) =====", logs.len());
             for l in &logs {

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -56,8 +56,28 @@ export interface WorkspaceAgent {
   knowledgeBaseIds: string[];
   activeSkillIds: string[];
   status: AgentStatus;
+  ragTopK: number;
+  ragRetrievalMode: string;
+  scratchpad: string;
+  /** 非 null 表示已被删除（软删除），仍保留用于历史消息里解析发送者名字。 */
+  deletedAt: number | null;
   createdAt: number;
   updatedAt: number;
+}
+
+export interface UpdateAgentRequest {
+  id: string;
+  name: string;
+  provider: string;
+  model: string;
+  baseUrl: string;
+  apiConfigId: string;
+  systemPrompt: string;
+  mcpServerIds: string[];
+  knowledgeBaseIds: string[];
+  activeSkillIds: string[];
+  ragTopK: number;
+  ragRetrievalMode: string;
 }
 
 export interface WorkspaceMessage {
@@ -90,6 +110,8 @@ export interface CreateAgentRequest {
   mcpServerIds: string[];
   knowledgeBaseIds: string[];
   activeSkillIds: string[];
+  ragTopK: number;
+  ragRetrievalMode: string;
 }
 
 export interface AgentProposalEvent {
@@ -119,6 +141,18 @@ export interface QuestionEvent {
 interface AgentStatusEvent {
   agentId: string;
   status: AgentStatus;
+}
+
+/** 持久化的待处理事项，用于补齐"页面没开着 / App 重启前发生"而错过的一次性事件。 */
+export interface PendingEvent {
+  id: string;
+  workspaceId: string;
+  agentId: string;
+  agentName: string;
+  kind: "proposal" | "sleep" | "question";
+  payload: Record<string, unknown>;
+  createdAt: number;
+  resolvedAt: number | null;
 }
 
 /** 目标 Agent 没有存活的后台任务（多半是重启过应用），消息发了但不会有人处理。 */
@@ -225,19 +259,60 @@ export const useWorkspaceStore = defineStore("workspace", () => {
     agents.value = await invoke<WorkspaceAgent[]>("workspace_list_agents", { workspaceId: currentWorkspaceId.value });
   };
 
+  const DEFAULT_HISTORY_LIMIT = 500;
+  const messagesLimit = ref(DEFAULT_HISTORY_LIMIT);
+  const logsLimit = ref(DEFAULT_HISTORY_LIMIT);
+  // 到没到底部（还有没有更早的记录）由"这次拉回来的条数是不是刚好等于
+  // 请求的 limit"来判断——等于就说明可能还有更早的被截掉了。
+  const hasMoreMessages = ref(false);
+  const hasMoreLogs = ref(false);
+
   const loadMessages = async () => {
     if (!currentWorkspaceId.value) return;
-    messages.value = await invoke<WorkspaceMessage[]>("workspace_list_messages", { workspaceId: currentWorkspaceId.value });
+    const result = await invoke<WorkspaceMessage[]>("workspace_list_messages", { workspaceId: currentWorkspaceId.value, limit: messagesLimit.value });
+    messages.value = result;
+    hasMoreMessages.value = result.length >= messagesLimit.value;
+  };
+
+  const loadMoreMessages = async () => {
+    messagesLimit.value += DEFAULT_HISTORY_LIMIT;
+    await loadMessages();
   };
 
   const loadLogs = async () => {
     if (!currentWorkspaceId.value) return;
-    logs.value = await invoke<WorkspaceLogEntry[]>("workspace_list_logs", { workspaceId: currentWorkspaceId.value });
+    const result = await invoke<WorkspaceLogEntry[]>("workspace_list_logs", { workspaceId: currentWorkspaceId.value, limit: logsLimit.value });
+    logs.value = result;
+    hasMoreLogs.value = result.length >= logsLimit.value;
+  };
+
+  const loadMoreLogs = async () => {
+    logsLimit.value += DEFAULT_HISTORY_LIMIT;
+    await loadLogs();
+  };
+
+  /** 补齐"页面没开着 / App 重启前发生"而错过的一次性提议/休眠/提问事件 --
+   *  按 id 去重，已经在内存队列里的（事件监听器实时推进来的）不重复添加。 */
+  const loadPendingEvents = async () => {
+    if (!currentWorkspaceId.value) return;
+    const events = await invoke<PendingEvent[]>("workspace_list_pending_events", { workspaceId: currentWorkspaceId.value });
+    for (const e of events) {
+      if (e.kind === "proposal" && !proposals.value.some((p) => p.proposalId === e.id)) {
+        const draft = e.payload.draft as CreateAgentRequest;
+        proposals.value.push({ proposalId: e.id, workspaceId: e.workspaceId, proposedByAgentId: e.agentId, proposedByAgentName: e.agentName, draft });
+      } else if (e.kind === "sleep" && !sleepRequests.value.some((r) => r.requestId === e.id)) {
+        sleepRequests.value.push({ requestId: e.id, workspaceId: e.workspaceId, agentId: e.agentId, agentName: e.agentName, reason: (e.payload.reason as string) ?? "" });
+      } else if (e.kind === "question" && !questions.value.some((q) => q.questionId === e.id)) {
+        questions.value.push({ questionId: e.id, workspaceId: e.workspaceId, agentId: e.agentId, agentName: e.agentName, question: (e.payload.question as string) ?? "" });
+      }
+    }
   };
 
   const selectWorkspace = async (workspaceId: string) => {
     currentWorkspaceId.value = workspaceId;
-    await Promise.all([loadAgents(), loadMessages(), loadLogs()]);
+    messagesLimit.value = DEFAULT_HISTORY_LIMIT;
+    logsLimit.value = DEFAULT_HISTORY_LIMIT;
+    await Promise.all([loadAgents(), loadMessages(), loadLogs(), loadPendingEvents()]);
   };
 
   const createAgent = async (request: CreateAgentRequest): Promise<WorkspaceAgent> => {
@@ -248,9 +323,18 @@ export const useWorkspaceStore = defineStore("workspace", () => {
     return agent;
   };
 
+  const updateAgent = async (request: UpdateAgentRequest) => {
+    console.log(`[Workspace] 更新 Agent: id=${request.id} name=${request.name}`);
+    await invoke("workspace_update_agent", { request });
+    await loadAgents();
+  };
+
   const deleteAgent = async (agentId: string) => {
     await invoke("workspace_delete_agent", { agentId });
-    agents.value = agents.value.filter((a) => a.id !== agentId);
+    // 软删除：保留在数组里（打上 deletedAt），历史消息/时间线才能继续解析出
+    // 它的名字而不是显示裸 UUID；界面上的花名册/下拉列表自己按 deletedAt 过滤。
+    const agent = agents.value.find((a) => a.id === agentId);
+    if (agent) agent.deletedAt = Date.now();
   };
 
   const sendUserMessage = async (toAgentId: string, content: string) => {
@@ -276,19 +360,27 @@ export const useWorkspaceStore = defineStore("workspace", () => {
     questions.value = questions.value.filter((q) => q.questionId !== questionId);
   };
 
-  /** 把一个 Agent id（或 "user"/"all"/"system"）解析成显示用的名字。 */
+  /** 把一个 Agent id（或 "user"/"all"/"system"）解析成显示用的名字。
+   *  `agents` 里包含软删除的 Agent（后端 workspace_list_agents 特意不过滤），
+   *  所以已删除 Agent 发过的历史消息仍能显示真实名字，而不是裸 UUID。 */
   const agentName = (agentId: string): string => {
     if (agentId === "user") return "用户";
     if (agentId === "all") return "所有人";
     if (agentId === "system") return "系统";
-    return agents.value.find((a) => a.id === agentId)?.name ?? agentId;
+    const agent = agents.value.find((a) => a.id === agentId);
+    if (!agent) return agentId;
+    return agent.deletedAt ? `${agent.name}（已删除）` : agent.name;
   };
+
+  /** 花名册/下拉列表等只应展示当前存活的 Agent。 */
+  const activeAgents = computed(() => agents.value.filter((a) => !a.deletedAt));
 
   return {
     workspaces,
     currentWorkspaceId,
     currentWorkspace,
     agents,
+    activeAgents,
     messages,
     logs,
     proposals,
@@ -303,8 +395,14 @@ export const useWorkspaceStore = defineStore("workspace", () => {
     selectWorkspace,
     loadAgents,
     loadMessages,
+    loadMoreMessages,
+    hasMoreMessages,
     loadLogs,
+    loadMoreLogs,
+    hasMoreLogs,
+    loadPendingEvents,
     createAgent,
+    updateAgent,
     deleteAgent,
     sendUserMessage,
     resolveProposal,

--- a/src/views/AgentTeamView.vue
+++ b/src/views/AgentTeamView.vue
@@ -21,12 +21,13 @@ import {
   NRadioGroup, NRadio, NCheckboxGroup, NCheckbox, NCard, NGrid, NGi, NList, NListItem, NThing,
   NTag, NTimeline, NTimelineItem, NPopconfirm, useMessage,
 } from "naive-ui";
-import { Add, TrashOutline, EnterOutline, AlarmOutline } from "@vicons/ionicons5";
+import { Add, TrashOutline, EnterOutline, AlarmOutline, PencilOutline, MegaphoneOutline } from "@vicons/ionicons5";
 
 import ChatMessage from "@/components/ChatMessage.vue";
 import {
   useWorkspaceStore, AGENT_GUIDELINES_BASE, AGENT_GUIDELINES_SUB,
-  type AgentProposalEvent, type AgentRole, type AgentStatus, type CreateAgentRequest, type WorkspaceLogEntry,
+  type AgentProposalEvent, type AgentRole, type AgentStatus, type CreateAgentRequest,
+  type UpdateAgentRequest, type WorkspaceAgent, type WorkspaceLogEntry,
 } from "@/stores/workspace";
 import { useSettingsStore } from "@/stores/settings";
 import { useMCPStore } from "@/stores/mcp";
@@ -108,8 +109,16 @@ const emptyAgentForm = (): CreateAgentRequest => ({
   mcpServerIds: [],
   knowledgeBaseIds: [],
   activeSkillIds: [],
+  ragTopK: 5,
+  ragRetrievalMode: "hybrid",
 });
 const agentForm = ref<CreateAgentRequest>(emptyAgentForm());
+
+const retrievalModeOptions = [
+  { label: "混合检索（推荐）", value: "hybrid" },
+  { label: "纯向量检索", value: "vector" },
+  { label: "纯关键词检索", value: "keyword" },
+];
 
 // 切换角色时，如果提示词还是另一个角色的默认准则（用户没改过），跟着换成
 // 当前角色的版本；用户已经自己写过内容就不动。
@@ -153,6 +162,72 @@ const handleCreateAgent = async () => {
     message.success("Agent 已创建");
   } catch (e) {
     message.error(`创建失败: ${e}`);
+  }
+};
+
+// ============ 编辑 Agent ============
+
+const showEditAgentModal = ref(false);
+const editAgentForm = ref<UpdateAgentRequest | null>(null);
+
+const openEditAgentModal = (agent: WorkspaceAgent) => {
+  editAgentForm.value = {
+    id: agent.id,
+    name: agent.name,
+    provider: agent.provider,
+    model: agent.model,
+    baseUrl: agent.baseUrl,
+    apiConfigId: agent.apiConfigId,
+    systemPrompt: agent.systemPrompt,
+    mcpServerIds: [...agent.mcpServerIds],
+    knowledgeBaseIds: [...agent.knowledgeBaseIds],
+    activeSkillIds: [...agent.activeSkillIds],
+    ragTopK: agent.ragTopK,
+    ragRetrievalMode: agent.ragRetrievalMode,
+  };
+  showEditAgentModal.value = true;
+};
+
+const handleUpdateAgent = async () => {
+  const form = editAgentForm.value;
+  if (!form) return;
+  if (!form.name.trim()) {
+    message.error("请填写 Agent 名称");
+    return;
+  }
+  if (!form.apiConfigId) {
+    message.error("请选择 API 配置");
+    return;
+  }
+  const config = settings.apiConfigs.find((c) => c.id === form.apiConfigId);
+  if (!config) {
+    message.error("找不到所选的 API 配置");
+    return;
+  }
+  try {
+    await workspace.updateAgent({ ...form, provider: config.provider, model: config.model, baseUrl: config.baseUrl });
+    showEditAgentModal.value = false;
+    message.success("Agent 已更新");
+  } catch (e) {
+    message.error(`更新失败: ${e}`);
+  }
+};
+
+// ============ 广播消息 ============
+
+const showBroadcastModal = ref(false);
+const broadcastContent = ref("");
+
+const handleBroadcastSend = async () => {
+  const content = broadcastContent.value.trim();
+  if (!content) return;
+  try {
+    await workspace.sendUserMessage("all", content);
+    broadcastContent.value = "";
+    showBroadcastModal.value = false;
+    message.success("已广播给所有 Agent");
+  } catch (e) {
+    message.error(`发送失败: ${e}`);
   }
 };
 
@@ -260,8 +335,9 @@ const openSchedulerPage = () => {
 
 // ============ 提醒：目标 Agent 没有存活的后台任务 ============
 
-// Agent 的后台循环只存在于内存里，应用重启后不会自动恢复；发消息给这样的
-// Agent 不会报错，只是永远没有回复。收到提醒就弹一条警告，然后清空队列。
+// Agent 的后台循环只存在于内存里；应用启动时会自动把每个工作组里的 Agent
+// 重新挂回循环，正常情况下不该再看到这个提醒。真出现了多半是极端时序问题
+// （比如启动过程中就有消息打进来），收到就弹一条警告，然后清空队列。
 watch(
   () => workspace.inactiveAgentNotices.length,
   () => {
@@ -269,7 +345,7 @@ watch(
       const notice = workspace.inactiveAgentNotices.shift();
       if (notice) {
         message.warning(
-          `「${notice.agentName}」当前不在运行状态，消息已发送但暂时不会有回复。请重新添加该 Agent 以恢复其工作能力。`,
+          `「${notice.agentName}」当前没有存活的后台任务，消息已发送但暂时不会有回复。通常重启一下应用就能自动恢复；如果重启后仍然这样，再考虑删除重建。`,
           { duration: 8000 }
         );
       }
@@ -424,6 +500,27 @@ onMounted(async () => {
             <n-form-item label="API 配置" required>
               <n-select v-model:value="proposalEdits[p.proposalId].apiConfigId" :options="settings.apiConfigOptions" placeholder="选择要使用的 API 配置" />
             </n-form-item>
+            <n-form-item label="MCP 工具" v-if="mcp.servers.length > 0">
+              <n-checkbox-group v-model:value="proposalEdits[p.proposalId].mcpServerIds">
+                <n-space vertical size="small">
+                  <n-checkbox v-for="s in mcp.servers" :key="s.id" :value="s.id" :label="s.name" />
+                </n-space>
+              </n-checkbox-group>
+            </n-form-item>
+            <n-form-item label="知识库" v-if="kb.knowledgeBases.length > 0">
+              <n-checkbox-group v-model:value="proposalEdits[p.proposalId].knowledgeBaseIds">
+                <n-space vertical size="small">
+                  <n-checkbox v-for="item in kb.knowledgeBases" :key="item.id" :value="item.id" :label="item.name" />
+                </n-space>
+              </n-checkbox-group>
+            </n-form-item>
+            <n-form-item label="Skill" v-if="skills.skills.length > 0">
+              <n-checkbox-group v-model:value="proposalEdits[p.proposalId].activeSkillIds">
+                <n-space vertical size="small">
+                  <n-checkbox v-for="sk in skills.skills" :key="sk.id" :value="sk.id" :label="sk.name" />
+                </n-space>
+              </n-checkbox-group>
+            </n-form-item>
           </n-form>
           <n-space justify="end">
             <n-button @click="handleRejectProposal(p)">拒绝</n-button>
@@ -456,6 +553,9 @@ onMounted(async () => {
                 <n-button size="small" quaternary @click="openSchedulerPage" :disabled="!workspace.currentWorkspace" title="管理定时任务">
                   <template #icon><n-icon><AlarmOutline /></n-icon></template>
                 </n-button>
+                <n-button size="small" quaternary @click="showBroadcastModal = true" :disabled="workspace.activeAgents.length === 0" title="广播给所有 Agent">
+                  <template #icon><n-icon><MegaphoneOutline /></n-icon></template>
+                </n-button>
                 <n-button size="small" type="primary" @click="openCreateAgentModal">
                   <template #icon><n-icon><Add /></n-icon></template>
                   添加 Agent
@@ -464,7 +564,7 @@ onMounted(async () => {
             </template>
             <n-list hoverable clickable class="agent-list">
               <n-list-item
-                v-for="agent in workspace.agents"
+                v-for="agent in workspace.activeAgents"
                 :key="agent.id"
                 :class="{ selected: agent.id === selectedAgentId }"
                 @click="selectedAgentId = agent.id"
@@ -479,19 +579,24 @@ onMounted(async () => {
                 <template #suffix>
                   <n-space vertical align="end" size="small">
                     <n-tag size="small" :type="statusMeta[agent.status].type">{{ statusMeta[agent.status].label }}</n-tag>
-                    <n-popconfirm positive-text="删除" negative-text="取消" @positive-click="handleDeleteAgent(agent.id)">
-                      <template #trigger>
-                        <n-button quaternary circle size="tiny" type="error" @click.stop>
-                          <template #icon><n-icon><TrashOutline /></n-icon></template>
-                        </n-button>
-                      </template>
-                      确定删除 Agent「{{ agent.name }}」？
-                    </n-popconfirm>
+                    <n-space size="small">
+                      <n-button quaternary circle size="tiny" @click.stop="openEditAgentModal(agent)" title="编辑">
+                        <template #icon><n-icon><PencilOutline /></n-icon></template>
+                      </n-button>
+                      <n-popconfirm positive-text="删除" negative-text="取消" @positive-click="handleDeleteAgent(agent.id)">
+                        <template #trigger>
+                          <n-button quaternary circle size="tiny" type="error" @click.stop>
+                            <template #icon><n-icon><TrashOutline /></n-icon></template>
+                          </n-button>
+                        </template>
+                        确定删除 Agent「{{ agent.name }}」？
+                      </n-popconfirm>
+                    </n-space>
                   </n-space>
                 </template>
               </n-list-item>
             </n-list>
-            <n-empty v-if="workspace.agents.length === 0" description="还没有 Agent" size="small" />
+            <n-empty v-if="workspace.activeAgents.length === 0" description="还没有 Agent" size="small" />
           </n-card>
         </n-gi>
 
@@ -500,8 +605,12 @@ onMounted(async () => {
             <n-empty v-if="!selectedAgent" description="选择一个 Agent 查看/发起对话" />
             <template v-else>
               <div class="message-scroll">
+                <n-button v-if="workspace.hasMoreMessages" size="tiny" quaternary block @click="workspace.loadMoreMessages" class="load-more-btn">
+                  加载更早的消息
+                </n-button>
                 <ChatMessage v-for="m in agentMessages" :key="m.id" :message="m" />
                 <n-empty v-if="agentMessages.length === 0" description="还没有消息" size="small" />
+                <p v-if="selectedAgent.status === 'running'" class="running-indicator">「{{ selectedAgent.name }}」正在处理…</p>
               </div>
               <div class="message-input-row">
                 <n-input v-model:value="newMessageContent" placeholder="给这个 Agent 发消息..." @keyup.enter="handleSendMessage" />
@@ -516,6 +625,9 @@ onMounted(async () => {
         <n-gi>
           <n-card title="活动时间线" class="panel-card" :bordered="false">
             <div class="timeline-scroll">
+              <n-button v-if="workspace.hasMoreLogs" size="tiny" quaternary block @click="workspace.loadMoreLogs" class="load-more-btn">
+                加载更早的记录
+              </n-button>
               <n-timeline>
                 <n-timeline-item
                   v-for="entry in timeline"
@@ -586,6 +698,14 @@ onMounted(async () => {
             </n-space>
           </n-checkbox-group>
         </n-form-item>
+        <template v-if="agentForm.knowledgeBaseIds.length > 0">
+          <n-form-item label="检索 top_k">
+            <n-input-number v-model:value="agentForm.ragTopK" :min="1" :max="20" />
+          </n-form-item>
+          <n-form-item label="检索模式">
+            <n-select v-model:value="agentForm.ragRetrievalMode" :options="retrievalModeOptions" />
+          </n-form-item>
+        </template>
         <n-form-item label="Skill" v-if="skills.skills.length > 0">
           <n-checkbox-group v-model:value="agentForm.activeSkillIds">
             <n-space vertical size="small">
@@ -598,6 +718,67 @@ onMounted(async () => {
         <n-space justify="end">
           <n-button @click="showCreateAgentModal = false">取消</n-button>
           <n-button type="primary" @click="handleCreateAgent">添加</n-button>
+        </n-space>
+      </template>
+    </n-modal>
+
+    <!-- 编辑 Agent -->
+    <n-modal v-model:show="showEditAgentModal" preset="card" title="编辑 Agent" style="width: 600px; max-height: 85vh" :content-style="{ overflowY: 'auto' }">
+      <n-form v-if="editAgentForm" label-placement="left" label-width="100px">
+        <n-form-item label="名称" required>
+          <n-input v-model:value="editAgentForm.name" placeholder="给这个 Agent 起个名字" />
+        </n-form-item>
+        <n-form-item label="API 配置" required>
+          <n-select v-model:value="editAgentForm.apiConfigId" :options="settings.apiConfigOptions" placeholder="选择已保存的 API 配置" />
+        </n-form-item>
+        <n-form-item label="系统提示词">
+          <n-input v-model:value="editAgentForm.systemPrompt" type="textarea" :rows="4" placeholder="这个 Agent 的职责说明..." />
+        </n-form-item>
+        <n-form-item label="MCP 工具" v-if="mcp.servers.length > 0">
+          <n-checkbox-group v-model:value="editAgentForm.mcpServerIds">
+            <n-space vertical size="small">
+              <n-checkbox v-for="s in mcp.servers" :key="s.id" :value="s.id" :label="s.name" />
+            </n-space>
+          </n-checkbox-group>
+        </n-form-item>
+        <n-form-item label="知识库" v-if="kb.knowledgeBases.length > 0">
+          <n-checkbox-group v-model:value="editAgentForm.knowledgeBaseIds">
+            <n-space vertical size="small">
+              <n-checkbox v-for="item in kb.knowledgeBases" :key="item.id" :value="item.id" :label="item.name" />
+            </n-space>
+          </n-checkbox-group>
+        </n-form-item>
+        <template v-if="editAgentForm.knowledgeBaseIds.length > 0">
+          <n-form-item label="检索 top_k">
+            <n-input-number v-model:value="editAgentForm.ragTopK" :min="1" :max="20" />
+          </n-form-item>
+          <n-form-item label="检索模式">
+            <n-select v-model:value="editAgentForm.ragRetrievalMode" :options="retrievalModeOptions" />
+          </n-form-item>
+        </template>
+        <n-form-item label="Skill" v-if="skills.skills.length > 0">
+          <n-checkbox-group v-model:value="editAgentForm.activeSkillIds">
+            <n-space vertical size="small">
+              <n-checkbox v-for="sk in skills.skills" :key="sk.id" :value="sk.id" :label="sk.name" />
+            </n-space>
+          </n-checkbox-group>
+        </n-form-item>
+      </n-form>
+      <template #footer>
+        <n-space justify="end">
+          <n-button @click="showEditAgentModal = false">取消</n-button>
+          <n-button type="primary" @click="handleUpdateAgent">保存</n-button>
+        </n-space>
+      </template>
+    </n-modal>
+
+    <!-- 广播消息 -->
+    <n-modal v-model:show="showBroadcastModal" preset="card" title="广播给所有 Agent" style="width: 480px">
+      <n-input v-model:value="broadcastContent" type="textarea" :rows="3" placeholder="这条消息会发给工作组里的每一个 Agent..." />
+      <template #footer>
+        <n-space justify="end">
+          <n-button @click="showBroadcastModal = false">取消</n-button>
+          <n-button type="primary" @click="handleBroadcastSend">发送</n-button>
         </n-space>
       </template>
     </n-modal>
@@ -653,7 +834,8 @@ onMounted(async () => {
 }
 
 .panel-card {
-  height: 640px;
+  height: calc(100vh - 22rem);
+  min-height: 26rem;
   display: flex;
   flex-direction: column;
 
@@ -663,6 +845,28 @@ onMounted(async () => {
     flex-direction: column;
     overflow: hidden;
   }
+
+  // 卡片标题不能换行——header-extra 里放的图标/按钮一多，flex 布局会把标题
+  // 挤到极窄，逐字换行成竖排。标题优先保留完整宽度，header-extra 自己收窄。
+  :deep(.n-card-header__main) {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  :deep(.n-card-header__extra) {
+    min-width: 0;
+  }
+}
+
+.load-more-btn {
+  margin-bottom: 8px;
+  color: $ink-faint;
+}
+
+.running-indicator {
+  padding: 4px 0;
+  font-size: $label-size;
+  color: $ink-faint;
+  transition: opacity $duration $ease;
 }
 
 .agent-list {


### PR DESCRIPTION
## 概述

上一轮 PR #71 只修了 Agent Team Mode 评估报告里会议机制相关的问题（原评估条目 1、14）和条目 8 的提示词缓解。这次覆盖报告里剩下的全部结构性问题。

> 注：下面用「条目 N」指代此前代码评估报告里的问题编号，**不是本仓库的 GitHub Issue**。

## 修复清单

- **条目 2（重启后自动恢复 Agent 循环）**：`main.rs` 启动时重新挂载每个工作组内存活 Agent 的后台任务，不再需要删除重建；卡在 Running/WaitingApproval/WaitingAnswer/Meeting 的陈旧状态重置为 Idle，Sleeping 保持不变
- **条目 3（虚假唤醒去重）**：本次唤醒若最新一条相关消息就是自己上次发的，直接跳过，不再对同一段历史重新推理导致重复回复
- **条目 4（待处理事项持久化）**：提议/休眠申请/提问持久化到新表 `workspace_pending_events`，新增 `workspace_list_pending_events` 命令，前端选中工作组时补齐拉取，不再因页面没开着 / App 重启而永久丢失
- **条目 5（MCP 工具权限旁路修复）**：只在 Agent 的 `mcp_server_ids` 白名单范围内查找工具执行，不再对全部已启用服务器广撒网（提示注入诱导调用未授权工具的路径被堵死）
- **条目 6（删除 Agent 改软删除）**：新增 `deleted_at` 列，历史消息/日志仍能正确显示已删除 Agent 的名字（标注"已删除"），不再是裸 UUID
- **条目 7（Agent 工作记忆）**：新增 `workspace_scratchpad` 工具，跨唤醒持久化的私有工作备忘，写入 system prompt，缓解"每次醒来只记得群聊记录"的问题
- **条目 10（Agent 可编辑）**：新增 `workspace_update_agent` 命令 + 前端编辑入口，不用再删了重建
- **条目 11（RAG 检索参数可配置）**：top_k / 检索模式从硬编码改为可配置
- **条目 12（SQLite 并发写健壮性）**：连接统一走带 `busy_timeout` 的 `open_conn`，写入失败不再静默吞掉
- **条目 13（取消粒度收紧）**：会议签到、提议/休眠/提问的阻塞等待都 race 上 `CancellationToken`，工作组/Agent 删除后不再空等最多 10 分钟
- **条目 15（测试覆盖）**：db 层新增软删除过滤、`update_agent`、scratchpad、pending_events 的单元测试
- **前端小项**：广播消息入口、`system` 发送者名字特判、面板高度自适应（原来固定 640px）、运行中视觉反馈、消息/日志"加载更多"、提议卡片补全 MCP/知识库/Skill 勾选

## 范围说明

模型能力对齐（流式/多模态/缓存，原评估条目 9）涉及改动主聊天路径共用的 `llm.rs`（~97KB，15+ 家 provider），按项目约定需要先过 `audit-llm-providers` 逐家核对，风险和体量都独立成篇，这次没有包含，留待后续单独处理。

## 验证

- `cargo test`：29 项全部通过（含本次新增的 5 个单元测试）
- `pnpm build` + `cargo build` + `pnpm tauri build`：三重编译门禁通过（release + NSIS 打包成功；更新器签名步骤因本机无 `TAURI_SIGNING_PRIVATE_KEY` 报错，与代码无关）
- **GUI 实测**（CDP driver 驱动真实应用 + DeepSeek 模型）：
  - scratchpad 工具写入/读出正确，无重复回复（验证条目 3 + 7）
  - 编辑 Agent 名称，保存后后端确认持久化（验证条目 10）
  - 广播消息，两个 Agent 均收到并各自回复（验证前端小项）
  - 删除 Agent 后，花名册里消失，但时间线上历史记录仍正确显示其名字并标注"已删除"（验证条目 6）
  - **应用重启后不做任何手动操作，直接发消息给存活 Agent，日志确认"应用启动：已恢复 1 个 Agent 的后台循环"，Agent 正常回复**（验证条目 2，全批改动里风险最高的一项，实测通过）
  - 复测会议流程，确认 `dispatch_tool_call` 签名变更（新增 cancel 参数）没有引入回归
  - 应用日志全程零报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)
