### PR TITLE
chore: 版本升至 0.2.0-beta.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.7",
+  "version": "0.2.0-beta.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.7"
+version = "0.2.0-beta.8"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.7",
+  "version": "0.2.0-beta.8",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
PR #73 合并后忘了带版本号升级，`v0.2.0-beta.7` 这个 tag 已经指向上一个 release 且有真实发布产物，不能复用。这个小 PR 把 `package.json`、`src-tauri/tauri.conf.json`、`src-tauri/Cargo.toml` 三处升到 `0.2.0-beta.8`，供打 tag 发布用。

已跑 `cargo build` 确认版本号变更编译通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)