### PR TITLE
fix: 修复 Agent Team 复审清单全部 21 项问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0-beta.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.10"
+version = "0.2.0-beta.11"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -287,6 +287,7 @@ fn main() {
             workspace::commands::workspace_list_pending_events,
             workspace::commands::workspace_list_agent_tasks,
             workspace::commands::workspace_set_task_done,
+            workspace::commands::workspace_set_scratchpad,
             // 定时任务命令
             scheduler::commands::schedule_create,
             scheduler::commands::schedule_list,
@@ -378,6 +379,35 @@ fn main() {
             {
                 use workspace::db as ws_db;
                 use workspace::types::AgentStatus;
+
+                // 上一次运行遗留的未决事项（提议/休眠/提问/工具审批）对应的等待
+                // 通道已随旧进程消亡，永远不可能再被批准或拒绝——统一标记过期，
+                // 否则前端每次选中工作组都会把它们拉出来，变成一批点了就报错、
+                // 又永远不消失的僵尸卡片。给对应工作组各写一条时间线日志，让
+                // 用户知道这些事项去哪了。
+                match ws_db::expire_unresolved_pending_events(&conn) {
+                    Ok(expired) => {
+                        for (workspace_id, count) in expired {
+                            log::info!("应用启动：工作组 {} 有 {} 件重启前的待处理事项已过期", workspace_id, count);
+                            let entry = workspace::types::WorkspaceLogEntry {
+                                id: uuid::Uuid::new_v4().to_string(),
+                                workspace_id,
+                                agent_id: None,
+                                kind: "pending_expired".to_string(),
+                                content: format!(
+                                    "应用重启，重启前遗留的 {} 件待处理事项已自动过期失效；如仍需要，请让对应 Agent 重新发起",
+                                    count
+                                ),
+                                created_at: chrono::Utc::now().timestamp_millis(),
+                            };
+                            if let Err(e) = ws_db::insert_log(&conn, &entry) {
+                                log::error!("写入待处理事项过期日志失败: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => log::error!("清理重启前遗留的待处理事项失败: {}", e),
+                }
+
                 match ws_db::list_workspaces(&conn) {
                     Ok(workspaces) => {
                         let mut resumed = 0;
@@ -403,6 +433,18 @@ fn main() {
                         log::info!("应用启动：已恢复 {} 个 Agent 的后台循环", resumed);
                     }
                     Err(e) => log::error!("恢复 Agent 循环失败（列出工作组）: {}", e),
+                }
+
+                // 补处理停机前积压的消息：恢复的循环只是重新挂上了，不会自己去
+                // 翻旧账——上次关掉应用时还没来得及回复的消息会一直没人理，
+                // 直到未来某条不相关的消息碰巧再唤醒它。这里全员 notify 一次：
+                // 虚假唤醒去重让没有积压的 Agent 以零成本（不发起任何模型调用）
+                // 跳过，休眠/暂停中的 Agent 状态也不会被这次探测动到。
+                {
+                    let handles = workspace_state.0.lock().unwrap();
+                    for handle in handles.values() {
+                        handle.notify.notify_one();
+                    }
                 }
             }
             app.manage(workspace_state);

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -323,15 +323,19 @@ pub async fn workspace_resolve_proposal(
     approved: bool,
     request: Option<CreateAgentRequest>,
     pending: State<'_, PendingProposals>,
-    db_state: State<'_, DbState>,
+    app_handle: AppHandle,
 ) -> Result<(), WorkspaceError> {
     let sender = {
         let mut map = pending.0.lock().unwrap();
         map.remove(&proposal_id)
     };
-    let sender = sender.ok_or_else(|| {
-        WorkspaceError::NotFound(format!("提议 {} 不存在或已被处理/超时", proposal_id))
-    })?;
+    let Some(sender) = sender else {
+        // 发起这条等待的阻塞调用已经不在了（超时收场、被别人抢先处理，或者
+        // 应用重启过）。顺手把数据库里的记录也标掉并广播移除，免得它变成一张
+        // 永远点不动的僵尸卡片。
+        mark_pending_event_resolved(&app_handle, &proposal_id).await;
+        return Err(WorkspaceError::NotFound(format!("提议 {} 已过期或已被处理", proposal_id)));
+    };
 
     let decision = if approved {
         match request {
@@ -347,7 +351,7 @@ pub async fn workspace_resolve_proposal(
     };
 
     let _ = sender.send(decision);
-    mark_pending_event_resolved(&db_state, &proposal_id).await;
+    mark_pending_event_resolved(&app_handle, &proposal_id).await;
     Ok(())
 }
 
@@ -360,17 +364,18 @@ pub async fn workspace_resolve_sleep_request(
     request_id: String,
     approved: bool,
     pending: State<'_, PendingSleepRequests>,
-    db_state: State<'_, DbState>,
+    app_handle: AppHandle,
 ) -> Result<(), WorkspaceError> {
     let sender = {
         let mut map = pending.0.lock().unwrap();
         map.remove(&request_id)
     };
-    let sender = sender.ok_or_else(|| {
-        WorkspaceError::NotFound(format!("休眠请求 {} 不存在或已被处理/超时", request_id))
-    })?;
+    let Some(sender) = sender else {
+        mark_pending_event_resolved(&app_handle, &request_id).await;
+        return Err(WorkspaceError::NotFound(format!("休眠请求 {} 已过期或已被处理", request_id)));
+    };
     let _ = sender.send(approved);
-    mark_pending_event_resolved(&db_state, &request_id).await;
+    mark_pending_event_resolved(&app_handle, &request_id).await;
     Ok(())
 }
 
@@ -380,17 +385,18 @@ pub async fn workspace_resolve_question(
     question_id: String,
     answer: String,
     pending: State<'_, PendingQuestions>,
-    db_state: State<'_, DbState>,
+    app_handle: AppHandle,
 ) -> Result<(), WorkspaceError> {
     let sender = {
         let mut map = pending.0.lock().unwrap();
         map.remove(&question_id)
     };
-    let sender = sender.ok_or_else(|| {
-        WorkspaceError::NotFound(format!("问题 {} 不存在或已被处理/超时", question_id))
-    })?;
+    let Some(sender) = sender else {
+        mark_pending_event_resolved(&app_handle, &question_id).await;
+        return Err(WorkspaceError::NotFound(format!("问题 {} 已过期或已被处理", question_id)));
+    };
     let _ = sender.send(answer);
-    mark_pending_event_resolved(&db_state, &question_id).await;
+    mark_pending_event_resolved(&app_handle, &question_id).await;
     Ok(())
 }
 
@@ -413,15 +419,18 @@ pub async fn workspace_resolve_tool_approval(
     approval_id: String,
     approved: bool,
     pending: State<'_, PendingToolApprovals>,
-    db_state: State<'_, DbState>,
+    app_handle: AppHandle,
 ) -> Result<(), WorkspaceError> {
     let sender = {
         let mut map = pending.0.lock().unwrap();
         map.remove(&approval_id)
     };
-    let sender = sender.ok_or_else(|| WorkspaceError::NotFound(format!("工具调用审批 {} 不存在或已被处理/超时", approval_id)))?;
+    let Some(sender) = sender else {
+        mark_pending_event_resolved(&app_handle, &approval_id).await;
+        return Err(WorkspaceError::NotFound(format!("工具调用审批 {} 已过期或已被处理", approval_id)));
+    };
     let _ = sender.send(approved);
-    mark_pending_event_resolved(&db_state, &approval_id).await;
+    mark_pending_event_resolved(&app_handle, &approval_id).await;
     Ok(())
 }
 
@@ -448,20 +457,38 @@ pub async fn workspace_set_task_done(
     db::set_task_done(&conn, &task_id, done)
 }
 
-async fn mark_pending_event_resolved(db_state: &DbState, id: &str) {
+/// 让用户能直接查看/编辑/清空一个 Agent 的工作备忘（scratchpad），而不是只能
+/// 任由 Agent 自己通过 workspace_scratchpad 工具维护——Agent 记了什么、记错了
+/// 什么，用户得看得见也改得动，这是"透明可控"的底线。传空字符串即清空。
+#[tauri::command]
+pub async fn workspace_set_scratchpad(
+    agent_id: String,
+    content: String,
+    db_state: State<'_, DbState>,
+) -> Result<(), WorkspaceError> {
     let db = db_state.0.lock().await;
-    match db::open_conn(&db.path) {
-        Ok(conn) => {
-            if let Err(e) = db::resolve_pending_event(&conn, id) {
-                log::error!("[workspace] 标记待处理事项已解决失败: {}", e);
-            }
-        }
-        Err(e) => log::error!("[workspace] 打开数据库连接失败（标记待处理事项）: {}", e),
-    }
+    let conn = db::open_conn(&db.path)?;
+    db::set_scratchpad(&conn, &agent_id, &content)
 }
 
-async fn mark_pending_event_resolved_via_handle(app_handle: &AppHandle, id: &str) {
-    mark_pending_event_resolved(&app_handle.state::<DbState>(), id).await;
+/// 标记一条待处理事项已解决，并广播 `workspace://pending-resolved` 事件让
+/// 前端移除对应卡片——不管它是被用户点的、被主 Agent 用工具处理的、还是
+/// 超时/取消自动收场的。没有这个事件，凡是"不经前端的手"解决的事项，卡片
+/// 都会在界面上一直挂着，用户再点一次就报"不存在或已被处理"。
+async fn mark_pending_event_resolved(app_handle: &AppHandle, id: &str) {
+    {
+        let db_state = app_handle.state::<DbState>();
+        let db = db_state.0.lock().await;
+        match db::open_conn(&db.path) {
+            Ok(conn) => {
+                if let Err(e) = db::resolve_pending_event(&conn, id) {
+                    log::error!("[workspace] 标记待处理事项已解决失败: {}", e);
+                }
+            }
+            Err(e) => log::error!("[workspace] 打开数据库连接失败（标记待处理事项）: {}", e),
+        }
+    }
+    let _ = app_handle.emit("workspace://pending-resolved", serde_json::json!({ "id": id }));
 }
 
 async fn record_pending_event(
@@ -563,10 +590,10 @@ pub async fn insert_workspace_log(
 }
 
 /// 落库一条消息，并唤醒它指向的那个（或那些）Agent。`to_agent_id` 为
-/// `"all"` 时，会广播给当前注册在 `WorkspaceState` 里的每一个其他 Agent
-/// （不只是这个工作组里的——Phase 1 里这样可以接受，因为 handle 是按 id
-/// 查找的，唤醒一个不相关的 Agent 只是一次空操作的开销；但如果以后
-/// `WorkspaceState` 需要直接跟踪工作组归属关系，这里就该按工作组收窄范围了）。
+/// `"all"` 时，只唤醒**这个工作组**的成员——启动时全量恢复循环之后，注册表
+/// 里挂着所有工作组的 Agent，按注册表广播会把别的工作组吵醒：多数情况下
+/// 虚假唤醒去重能兜住，但一个历史停在未回复消息上的 Agent 会凭空开始推理，
+/// 休眠中的 Agent 也会被无谓打扰。
 pub async fn send_workspace_message(
     app_handle: &AppHandle,
     workspace_id: &str,
@@ -630,16 +657,28 @@ async fn send_workspace_message_impl(
     if !wake {
         return;
     }
-    let workspace_state = app_handle.state::<WorkspaceState>();
-    let handles = workspace_state.0.lock().unwrap();
     if to_agent_id == "all" {
-        for (id, handle) in handles.iter() {
+        // 先查成员名单再锁 handle 表——std::sync::Mutex 的锁不能跨 await 持有。
+        let member_ids: Vec<String> = list_agents_for_workspace(app_handle, workspace_id)
+            .await
+            .into_iter()
+            .map(|a| a.id)
+            .collect();
+        let workspace_state = app_handle.state::<WorkspaceState>();
+        let handles = workspace_state.0.lock().unwrap();
+        for id in &member_ids {
             if id != from_agent_id {
-                handle.notify.notify_one();
+                if let Some(handle) = handles.get(id) {
+                    handle.notify.notify_one();
+                }
             }
         }
-    } else if let Some(handle) = handles.get(to_agent_id) {
-        handle.notify.notify_one();
+    } else {
+        let workspace_state = app_handle.state::<WorkspaceState>();
+        let handles = workspace_state.0.lock().unwrap();
+        if let Some(handle) = handles.get(to_agent_id) {
+            handle.notify.notify_one();
+        }
     }
 }
 
@@ -660,27 +699,45 @@ async fn find_main_agent_id(app_handle: &AppHandle, workspace_id: &str) -> Optio
         .map(|a| a.id)
 }
 
-/// 一个子 Agent 的休眠请求被批准之后，检查这个工作组里是不是所有子 Agent
-/// 都已经进入 `Sleeping` 状态；如果是，给主 Agent 发消息（同时也会唤醒它），
-/// 请它验收一下任务是否已经完成。
+/// 一个子 Agent 的休眠请求被批准（或有子 Agent 进入 Error 状态）之后，检查
+/// 这个工作组里是不是所有子 Agent 都已停止推进；如果是，给主 Agent 发消息
+/// （同时也会唤醒它），请它验收一下任务是否已经完成。
+///
+/// Error 也算"不会再自己推进"的终态——只认 Sleeping 的话，一个报错卡死的
+/// 子 Agent 会让验收永远无法触发，任务无声烂尾。但要求至少有一个真的在
+/// 休眠：全员报错的场景由逐个的出错上报（`notify_main_agent_of_error`）
+/// 覆盖，再发一条"请验收"只会误导主 Agent 以为有成果可验。
 async fn maybe_trigger_main_agent_review(app_handle: &AppHandle, workspace_id: &str) {
     let agents = list_agents_for_workspace(app_handle, workspace_id).await;
     let subs: Vec<_> = agents.iter().filter(|a| a.role == AgentRole::Sub).collect();
-    if subs.is_empty() || !subs.iter().all(|a| a.status == AgentStatus::Sleeping) {
+    if subs.is_empty() {
+        return;
+    }
+    let sleeping = subs.iter().filter(|a| a.status == AgentStatus::Sleeping).count();
+    let errored = subs.iter().filter(|a| a.status == AgentStatus::Error).count();
+    if sleeping == 0 || sleeping + errored < subs.len() {
         return;
     }
     let Some(main) = agents.iter().find(|a| a.role == AgentRole::Main) else {
         return;
     };
 
+    let status_brief = if errored > 0 {
+        format!("（休眠 {} 个，异常 {} 个）", sleeping, errored)
+    } else {
+        String::new()
+    };
     send_workspace_message(
         app_handle,
         workspace_id,
         "system",
         &main.id,
-        "工作组内所有子 Agent 都已进入休眠状态，请验收当前任务进度：如果任务已经完成，用 workspace_message \
-         告知用户；如果还没完成，可以用 workspace_message 叫醒某个子 Agent 继续推进，或者用 workspace_create_agent \
-         创建新的 Agent。",
+        &format!(
+            "工作组内所有子 Agent 都已停止推进{}，请验收当前任务进度：如果任务已经完成，用 workspace_message \
+             告知用户；如果还没完成，可以用 workspace_message 叫醒某个子 Agent 继续推进（给异常状态的 Agent \
+             发消息也会让它重试），或者用 workspace_create_agent 创建新的 Agent。",
+            status_brief
+        ),
     )
     .await;
     insert_workspace_log(
@@ -688,7 +745,36 @@ async fn maybe_trigger_main_agent_review(app_handle: &AppHandle, workspace_id: &
         workspace_id,
         None,
         "acceptance_review",
-        "所有子 Agent 已休眠，已唤醒主 Agent 验收任务进度".to_string(),
+        format!("所有子 Agent 已停止推进{}，已唤醒主 Agent 验收任务进度", status_brief),
+    )
+    .await;
+}
+
+/// 子 Agent 进入 Error 状态时，把出错的事实和原因告知主 Agent（同时唤醒它），
+/// 让它决定重试、换人还是上报用户——否则一个悄悄倒下的 Agent 只会留下一条
+/// 日志，任务无声烂尾。主 Agent 自己出错时没有更上级可通知，状态标签和
+/// 错误日志的悬浮提示已经能让用户看到。
+async fn notify_main_agent_of_error(app_handle: &AppHandle, workspace_id: &str, agent_id: &str, error: &str) {
+    let agents = list_agents_for_workspace(app_handle, workspace_id).await;
+    let Some(errored) = agents.iter().find(|a| a.id == agent_id) else {
+        return;
+    };
+    if errored.role == AgentRole::Main {
+        return;
+    }
+    let Some(main) = agents.iter().find(|a| a.role == AgentRole::Main) else {
+        return;
+    };
+    send_workspace_message(
+        app_handle,
+        workspace_id,
+        "system",
+        &main.id,
+        &format!(
+            "Agent「{}」处理消息时出错：{}。请决定下一步：给它发消息让它重试、用 workspace_message 告知用户\
+             检查它的配置、或安排其他 Agent 接手它的工作。",
+            errored.name, error
+        ),
     )
     .await;
 }
@@ -806,6 +892,9 @@ async fn run_agent_loop(
     notify: Arc<Notify>,
     cancel: CancellationToken,
 ) {
+    // 只在"进入 Error"的那一刻通知主 Agent 一次，连续出错不重复刷屏；
+    // 成功跑完一轮就复位，之后再出错会重新通知。
+    let mut error_notified = false;
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
@@ -815,10 +904,30 @@ async fn run_agent_loop(
             break;
         }
 
-        if let Err(e) = process_agent_wake(&app_handle, &workspace_id, &agent_id, &cancel).await {
-            log::error!("Workspace agent {} 处理失败: {}", agent_id, e);
-            set_agent_status(&app_handle, &agent_id, AgentStatus::Error).await;
-            insert_workspace_log(&app_handle, &workspace_id, Some(agent_id.clone()), "error", e.to_string()).await;
+        match process_agent_wake(&app_handle, &workspace_id, &agent_id, &cancel).await {
+            Ok(()) => {
+                error_notified = false;
+            }
+            Err(e) => {
+                log::error!("Workspace agent {} 处理失败: {}", agent_id, e);
+                insert_workspace_log(&app_handle, &workspace_id, Some(agent_id.clone()), "error", e.to_string()).await;
+                // 用户已手动暂停的 Agent 保持 Paused，别用 Error 覆盖掉这个
+                // 明确的人为决定；也不再向主 Agent 上报（用户已经介入了）。
+                let paused = matches!(
+                    load_agent(&app_handle, &agent_id).await,
+                    Ok(Some(a)) if a.status == AgentStatus::Paused
+                );
+                if !paused {
+                    set_agent_status(&app_handle, &agent_id, AgentStatus::Error).await;
+                    if !error_notified {
+                        error_notified = true;
+                        notify_main_agent_of_error(&app_handle, &workspace_id, &agent_id, &e.to_string()).await;
+                        // Error 属于验收条件里的终态之一：这个 Agent 一倒，
+                        // 可能恰好凑齐"全员停止推进"。
+                        maybe_trigger_main_agent_review(&app_handle, &workspace_id).await;
+                    }
+                }
+            }
         }
     }
     log::info!("Workspace agent {} 循环已停止", agent_id);
@@ -886,16 +995,13 @@ async fn process_agent_wake(
         agent.name, agent_id, workspace.name, agent.provider, agent.model
     );
 
-    // Agent 在轮转发言时保持 Meeting 状态可见；只有开始一次普通（非会议）
-    // 唤醒时，才把状态提升为 Running。
-    if agent.status != AgentStatus::Meeting {
-        set_agent_status(app_handle, agent_id, AgentStatus::Running).await;
-    }
-
+    // 注意：确认"确实有新内容要处理"之前不碰状态。以前这里先把状态改成
+    // Running、空转检查不通过再改成 Idle——一次虚假唤醒（比如广播的余波）就
+    // 会把休眠中 Agent 的 Sleeping 状态洗成 Idle，"全员休眠→触发验收"的
+    // 条件随之被无声破坏。
     let chat_history = build_chat_history(app_handle, workspace_id, &agent).await;
     if chat_history.is_empty() {
-        log::debug!("[workspace] Agent「{}」历史消息为空，跳过本次唤醒", agent.name);
-        set_agent_status(app_handle, agent_id, AgentStatus::Idle).await;
+        log::debug!("[workspace] Agent「{}」历史消息为空，跳过本次唤醒（状态保持 {:?}）", agent.name, agent.status);
         return Ok(());
     }
     // 虚假唤醒去重：`Notify` 的 permit 语义下，处理期间收到的通知会在处理结束
@@ -903,9 +1009,14 @@ async fn process_agent_wake(
     // 没有任何人在这之后说过话，没有新内容可回应，直接跳过，避免对着同一段
     // 历史重新推理一遍、很可能又重复回复一次。
     if chat_history.last().map(|m| m.role.as_str()) == Some("assistant") {
-        log::debug!("[workspace] Agent「{}」自上次发言后没有新消息，跳过本次唤醒", agent.name);
-        set_agent_status(app_handle, agent_id, AgentStatus::Idle).await;
+        log::debug!("[workspace] Agent「{}」自上次发言后没有新消息，跳过本次唤醒（状态保持 {:?}）", agent.name, agent.status);
         return Ok(());
+    }
+
+    // Agent 在轮转发言时保持 Meeting 状态可见；只有开始一次普通（非会议）
+    // 唤醒时，才把状态提升为 Running。
+    if agent.status != AgentStatus::Meeting {
+        set_agent_status(app_handle, agent_id, AgentStatus::Running).await;
     }
     let latest_query = chat_history
         .iter()
@@ -1046,11 +1157,16 @@ async fn process_agent_wake(
         );
     }
 
-    // 别覆盖掉 Sleeping（由 workspace_sleep 设置）或 Meeting（由会议协调器
-    // 管理，会议结束时协调器自己会把与会者状态复位成 Idle）。
+    // 别覆盖掉 Sleeping（由 workspace_sleep 设置）、Meeting（由会议协调器
+    // 管理，散会时协调器自己会还原与会者状态），也别覆盖 Paused——用户在
+    // 这轮进行中按下的"暂停"是紧急停止，如果这里照旧复位成 Idle，暂停就
+    // 会在当前轮跑完的瞬间自动失效，下一条消息照常把它唤醒。
     let blocking = matches!(
         load_agent(app_handle, agent_id).await,
-        Ok(Some(WorkspaceAgent { status: AgentStatus::Sleeping | AgentStatus::Meeting, .. }))
+        Ok(Some(WorkspaceAgent {
+            status: AgentStatus::Sleeping | AgentStatus::Meeting | AgentStatus::Paused,
+            ..
+        }))
     );
     if !blocking {
         set_agent_status(app_handle, agent_id, AgentStatus::Idle).await;
@@ -1292,8 +1408,8 @@ fn workspace_tool_defs(agent: &WorkspaceAgent) -> Vec<MCPTool> {
         server_name: "workspace".to_string(),
         name: "workspace_meeting".to_string(),
         description: "发起一次工作组会议（每个工作组同时只能有一场）。组内其他 Agent 会被邀请参会，\
-            大家轮流发言，每条发言都会实时同步给所有与会者。你是本场会议的主持人：想散会时，\
-            在签到（workspace_meeting_checkin）时把 end_meeting 设为 true。"
+            大家轮流发言；轮到某位与会者发言时，它会一次性收到此前错过的全部发言。你是本场会议的\
+            主持人：想散会时，在签到（workspace_meeting_checkin）时把 end_meeting 设为 true。"
             .to_string(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -1309,8 +1425,9 @@ fn workspace_tool_defs(agent: &WorkspaceAgent) -> Vec<MCPTool> {
         server_id: "workspace".to_string(),
         server_name: "workspace".to_string(),
         name: "workspace_meeting_checkin".to_string(),
-        description: "会议签到/发言工具。收到会议邀请后立即调用它签到（content 留空）；之后每次收到\
-            本工具的结果，都按结果里的 instruction 再次调用：轮到你发言时把发言写进 content。\
+        description: "会议签到/发言工具。收到会议邀请后立即调用它签到（content 留空）；签到后工具会\
+            挂起等待，轮到你发言或会议结束时才返回结果（附上你错过的全部发言）。每次收到本工具的结果，\
+            都按结果里的 instruction 再次调用：轮到你发言时把发言写进 content。\
             主持人可以在任意一次签到时把 end_meeting 设为 true 结束会议。"
             .to_string(),
         input_schema: serde_json::json!({
@@ -1495,8 +1612,7 @@ async fn dispatch_tool_call(
             match sender {
                 Some(tx) => {
                     let _ = tx.send(approved);
-                    let db_state = app_handle.state::<DbState>();
-                    mark_pending_event_resolved(&db_state, &request_id).await;
+                    mark_pending_event_resolved(app_handle, &request_id).await;
                     serde_json::json!({ "status": "ok" })
                 }
                 None => serde_json::json!({ "error": format!("休眠请求 {} 不存在或已被处理/超时", request_id) }),
@@ -1574,6 +1690,9 @@ async fn dispatch_tool_call(
                     if let Err(e) = db::insert_task(&conn, &task) {
                         return serde_json::json!({ "error": format!("新增任务失败: {}", e) });
                     }
+                    // 告诉前端这个 Agent 的任务清单变了——否则用户面板上看到的
+                    // 一直是旧清单，只能靠手动刷新按钮兜底。
+                    let _ = app_handle.emit("workspace://tasks-updated", serde_json::json!({ "agentId": agent.id }));
                     serde_json::json!({ "status": "added", "taskId": task.id })
                 }
                 "complete" | "reopen" => {
@@ -1583,6 +1702,7 @@ async fn dispatch_tool_call(
                     if let Err(e) = db::set_task_done(&conn, task_id, action == "complete") {
                         return serde_json::json!({ "error": e.to_string() });
                     }
+                    let _ = app_handle.emit("workspace://tasks-updated", serde_json::json!({ "agentId": agent.id }));
                     serde_json::json!({ "status": "ok" })
                 }
                 "remove" => {
@@ -1592,6 +1712,7 @@ async fn dispatch_tool_call(
                     if let Err(e) = db::delete_task(&conn, task_id) {
                         return serde_json::json!({ "error": format!("删除任务失败: {}", e) });
                     }
+                    let _ = app_handle.emit("workspace://tasks-updated", serde_json::json!({ "agentId": agent.id }));
                     serde_json::json!({ "status": "removed" })
                 }
                 "list" => match db::list_tasks(&conn, &agent.id) {
@@ -1650,6 +1771,14 @@ async fn dispatch_tool_call(
                 .chain(others.iter().map(|a| (a.id.clone(), a.name.clone())))
                 .collect();
             let order_display = participants.iter().map(|(_, n)| n.as_str()).collect::<Vec<_>>().join(" → ");
+            // 记住入场前正在休眠的与会者：散会时还原成休眠而不是一律复位待命。
+            // 开会把人叫起来没问题（会议邀请也是消息），但不能顺手吞掉它们
+            // "任务已完成"的声明，否则"全员休眠→触发验收"的机制会被开会打断。
+            let sleeping_before: std::collections::HashSet<String> = others
+                .iter()
+                .filter(|a| a.status == AgentStatus::Sleeping)
+                .map(|a| a.id.clone())
+                .collect();
 
             for (id, _) in &participants {
                 set_agent_status(app_handle, id, AgentStatus::Meeting).await;
@@ -1674,8 +1803,9 @@ async fn dispatch_tool_call(
                     &a.id,
                     &format!(
                         "【会议邀请】「{}」发起了会议，议题：「{}」。请立即调用 workspace_meeting_checkin \
-                         工具签到参会：meeting_id 填 \"{}\"，content 留空。之后每次收到该工具的结果，都按\
-                         结果里的 instruction 再次调用；轮到你发言时，把发言写进 content 参数。",
+                         工具签到参会：meeting_id 填 \"{}\"，content 留空。签到后工具会挂起等待，轮到你\
+                         发言或会议结束时才会返回结果（结果里会附上你错过的全部发言）；返回后按结果里的 \
+                         instruction 继续。",
                         agent.name, topic, meeting_id
                     ),
                 )
@@ -1689,6 +1819,7 @@ async fn dispatch_tool_call(
                 initiator_id: agent.id.clone(),
                 participants,
                 max_speeches,
+                sleeping_before,
             };
             let coordinator_app = app_handle.clone();
             tauri::async_runtime::spawn(async move {
@@ -1817,6 +1948,7 @@ async fn propose_agent_creation(
             "proposedByAgentId": proposing_agent.id,
             "proposedByAgentName": proposing_agent.name,
             "draft": draft,
+            "createdAt": Utc::now().timestamp_millis(),
         }),
     );
 
@@ -1853,7 +1985,7 @@ async fn propose_agent_creation(
 
     let response = match outcome {
         None => {
-            mark_pending_event_resolved_via_handle(app_handle, &proposal_id).await;
+            mark_pending_event_resolved(app_handle, &proposal_id).await;
             return serde_json::json!({ "status": "cancelled", "message": "工作组已被删除" });
         }
         Some(Ok(Ok(ProposalDecision::Approved(final_request)))) => {
@@ -1870,7 +2002,7 @@ async fn propose_agent_creation(
             serde_json::json!({ "status": "timed_out", "message": "用户在 10 分钟内没有响应，提议已取消" })
         }
     };
-    mark_pending_event_resolved_via_handle(app_handle, &proposal_id).await;
+    mark_pending_event_resolved(app_handle, &proposal_id).await;
     response
 }
 
@@ -1898,6 +2030,7 @@ async fn request_sleep_approval(
         serde_json::json!({
             "requestId": request_id, "workspaceId": workspace_id,
             "agentId": agent.id, "agentName": agent.name, "reason": reason,
+            "createdAt": Utc::now().timestamp_millis(),
         }),
     );
 
@@ -1939,7 +2072,7 @@ async fn request_sleep_approval(
 
     let approved = match outcome {
         None => {
-            mark_pending_event_resolved_via_handle(app_handle, &request_id).await;
+            mark_pending_event_resolved(app_handle, &request_id).await;
             return false;
         }
         Some(Ok(Ok(approved))) => approved,
@@ -1949,7 +2082,7 @@ async fn request_sleep_approval(
             false
         }
     };
-    mark_pending_event_resolved_via_handle(app_handle, &request_id).await;
+    mark_pending_event_resolved(app_handle, &request_id).await;
     approved
 }
 
@@ -1975,6 +2108,7 @@ async fn request_user_answer(
         serde_json::json!({
             "questionId": question_id, "workspaceId": workspace_id,
             "agentId": agent.id, "agentName": agent.name, "question": question,
+            "createdAt": Utc::now().timestamp_millis(),
         }),
     );
     record_pending_event(
@@ -1999,17 +2133,40 @@ async fn request_user_answer(
 
     let answer = match outcome {
         None => {
-            mark_pending_event_resolved_via_handle(app_handle, &question_id).await;
+            mark_pending_event_resolved(app_handle, &question_id).await;
             return "（工作组已被删除）".to_string();
         }
-        Some(Ok(Ok(answer))) => answer,
+        Some(Ok(Ok(answer))) => {
+            // 把回答落库成一条静默消息（不触发唤醒——回答已经通过工具结果送进
+            // 当前这次唤醒了）：时间线上问答俱全，Agent 之后的唤醒按消息表重建
+            // 历史时，用户说过的话也不会凭空消失。
+            let brief: String = question.chars().take(40).collect();
+            let ellipsis = if question.chars().count() > 40 { "…" } else { "" };
+            send_workspace_message_silent(
+                app_handle,
+                workspace_id,
+                "user",
+                &agent.id,
+                &format!("（回答提问「{}{}」）{}", brief, ellipsis, answer),
+            )
+            .await;
+            answer
+        }
         Some(Ok(Err(_))) => "（用户没有回答）".to_string(),
         Some(Err(_)) => {
             app_handle.state::<PendingQuestions>().0.lock().unwrap().remove(&question_id);
+            insert_workspace_log(
+                app_handle,
+                workspace_id,
+                Some(agent.id.clone()),
+                "question",
+                format!("{} 的提问超时未获回答", agent.name),
+            )
+            .await;
             "（用户在限定时间内没有回答）".to_string()
         }
     };
-    mark_pending_event_resolved_via_handle(app_handle, &question_id).await;
+    mark_pending_event_resolved(app_handle, &question_id).await;
     answer
 }
 
@@ -2029,7 +2186,27 @@ const DANGEROUS_TOOL_KEYWORDS: &[&str] = &[
 
 fn is_dangerous_tool(name: &str, description: &str) -> bool {
     let haystack = format!("{} {}", name, description).to_lowercase();
-    DANGEROUS_TOOL_KEYWORDS.iter().any(|kw| haystack.contains(kw))
+    DANGEROUS_TOOL_KEYWORDS.iter().any(|kw| {
+        if kw.is_ascii() {
+            // 英文关键词要求整词命中："skill" 不该因为包含 "kill" 被拦下，
+            // "commands" 也不该被 "command" 误伤。下划线/连字符/空格/中文
+            // 字符都算词边界，所以 "kill_process"、"write_file" 照常命中。
+            contains_ascii_word(&haystack, kw)
+        } else {
+            // 中文没有词边界可言，维持子串匹配。
+            haystack.contains(kw)
+        }
+    })
+}
+
+fn contains_ascii_word(haystack: &str, word: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    haystack.match_indices(word).any(|(pos, _)| {
+        let before_ok = pos == 0 || !bytes[pos - 1].is_ascii_alphanumeric();
+        let end = pos + word.len();
+        let after_ok = end >= bytes.len() || !bytes[end].is_ascii_alphanumeric();
+        before_ok && after_ok
+    })
 }
 
 /// 注册一条待处理的 MCP 工具调用审批，通知前端，然后阻塞等待，直到用户
@@ -2058,6 +2235,7 @@ async fn request_tool_approval(
             "approvalId": approval_id, "workspaceId": workspace_id,
             "agentId": agent.id, "agentName": agent.name,
             "toolName": tool_name, "arguments": arguments,
+            "createdAt": Utc::now().timestamp_millis(),
         }),
     );
     record_pending_event(
@@ -2089,7 +2267,7 @@ async fn request_tool_approval(
 
     let approved = match outcome {
         None => {
-            mark_pending_event_resolved_via_handle(app_handle, &approval_id).await;
+            mark_pending_event_resolved(app_handle, &approval_id).await;
             return false;
         }
         Some(Ok(Ok(approved))) => approved,
@@ -2099,7 +2277,7 @@ async fn request_tool_approval(
             false
         }
     };
-    mark_pending_event_resolved_via_handle(app_handle, &approval_id).await;
+    mark_pending_event_resolved(app_handle, &approval_id).await;
     approved
 }
 
@@ -2122,5 +2300,16 @@ mod danger_classifier_tests {
         assert!(!is_dangerous_tool("search_web", "Search the web for a query"));
         assert!(!is_dangerous_tool("get_weather", "查询天气预报"));
         assert!(!is_dangerous_tool("read_file", "读取文件内容"));
+    }
+
+    #[test]
+    fn word_boundary_avoids_substring_false_positives() {
+        // "skill" 里包含 "kill"、"commands" 里包含 "command"——整词匹配后
+        // 这些不该再被误判成危险工具。
+        assert!(!is_dangerous_tool("list_skills", "List all available skills"));
+        assert!(!is_dangerous_tool("get_commands_help", "Show available commands reference"));
+        // 但下划线/空格分隔的真实危险动词照常命中。
+        assert!(is_dangerous_tool("kill_process", "Kill a running process by pid"));
+        assert!(is_dangerous_tool("run_command", "Run a shell command"));
     }
 }

--- a/src-tauri/src/workspace/db.rs
+++ b/src-tauri/src/workspace/db.rs
@@ -639,6 +639,25 @@ pub fn list_unresolved_pending_events(conn: &Connection, workspace_id: &str) -> 
     Ok(rows.filter_map(|r| r.ok()).collect())
 }
 
+/// 把**所有**未解决的待处理事项统一标记为已解决（过期），返回每个工作组
+/// 被过期的条数。只该在应用启动时调用：这些事项对应的等待通道（oneshot）
+/// 已随上一个进程消亡，永远不可能再被批准或拒绝——不清掉它们，前端每次
+/// 选中工作组都会把它们拉出来，变成一批点了就报错、又永远不消失的僵尸卡片。
+pub fn expire_unresolved_pending_events(conn: &Connection) -> Result<Vec<(String, i64)>, WorkspaceError> {
+    let mut stmt = conn.prepare(
+        "SELECT workspace_id, COUNT(*) FROM workspace_pending_events WHERE resolved_at IS NULL GROUP BY workspace_id",
+    )?;
+    let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))?;
+    let expired: Vec<(String, i64)> = rows.filter_map(|r| r.ok()).collect();
+    if !expired.is_empty() {
+        conn.execute(
+            "UPDATE workspace_pending_events SET resolved_at = ?1 WHERE resolved_at IS NULL",
+            rusqlite::params![chrono::Utc::now().timestamp_millis()],
+        )?;
+    }
+    Ok(expired)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/workspace/meeting.rs
+++ b/src-tauri/src/workspace/meeting.rs
@@ -2,21 +2,28 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Agent Team Mode 的屏障式（barrier-style）会议协调。
+//! Agent Team Mode 的会议协调：点名发言制。
 //!
-//! 会议采用"集合点"同步协议：所有与会 Agent 都挂起在
-//! `workspace_meeting_checkin` 工具调用上，协调器等人到齐后统一放行，把新
-//! 发言作为工具结果同时发给所有人——发言因此直接进入每个与会者当前唤醒的
-//! 模型上下文，人人都能听到彼此在说什么。放行时同时指定下一位发言人。
+//! 与会 Agent 调用 `workspace_meeting_checkin` 签到后，工具调用就挂起在
+//! `reply` 上（挂起的等待不产生任何模型调用）。协调器每轮只放行**当前被
+//! 点名的发言人**：把它错过的发言按 `seen` 进度一次性补给它，并要求它在
+//! 下一次签到里带上自己的发言；其余听众继续挂起，直到轮到自己或散会。
+//! 这样一场 S 条发言、N 人参加的会议只需要约 S + N 次模型调用——旧的
+//! 屏障式协议每条发言都放行全员重新签到，成本是 S × N，其中绝大多数调用
+//! 只是空喊"我还在听"（默认 30 条发言 × 5 人 ≈ 150 次真实 API 调用，
+//! 约 120 次毫无信息量）。
 //!
 //! 发言另以静默广播消息落库（不唤醒任何 Agent，见
 //! `send_workspace_message_silent`），既让前端时间线实时可见，也让散会后的
 //! 历史重建保留会议内容，避免"会上说过的话散会就忘"。
 //!
-//! 结束条件：主持人（发起人）在任意一次签到时传 `end_meeting=true`；或发言
-//! 数达到上限（默认 30，发起时可自定义）后，协调器把发言权交给主持人做总结
-//! 收场。每轮集合有超时，超时未签到的与会者标记缺席、不再等待；缺席者之后
-//! 补签到会自动重新入会，并补收缺席期间错过的发言。
+//! 结束条件：主持人（发起人）在签到时传 `end_meeting=true`；或发言数达到
+//! 上限（默认 30，发起时可自定义）后，协调器把发言权交给主持人做总结收场。
+//! 被点名的发言人有签到时限，超时标记缺席、发言权顺延；缺席者之后补签到会
+//! 自动重新入会，并在下次被点名或散会时补收错过的发言。
+//!
+//! 散会时还原与会者状态：入场前在休眠的还原成休眠（开会不该吞掉"任务已
+//! 完成"的声明，否则"全员休眠→触发验收"会被一场会议打断），其余复位 Idle。
 
 use super::commands::{
     insert_workspace_log, load_agent, send_workspace_message_silent, set_agent_status,
@@ -30,14 +37,14 @@ use tokio::sync::{mpsc, oneshot};
 
 pub const DEFAULT_MAX_SPEECHES: u32 = 30;
 pub const MAX_MAX_SPEECHES: u32 = 200;
-/// 每轮集合（等所有未缺席与会者签到）的时限，超时者标记缺席。
-const CYCLE_TIMEOUT_SECS: u64 = 180;
+/// 被点名的发言人从放行到交回发言的时限，超时标记缺席、发言权顺延。
+const TURN_TIMEOUT_SECS: u64 = 180;
 
 /// 一次签到：与会 Agent 调用 `workspace_meeting_checkin`（发起人则是
 /// `workspace_meeting` 本身）后，其工具调用挂起在 `reply` 上等协调器放行。
 pub struct MeetingCheckIn {
     pub agent_id: String,
-    /// 轮到该 Agent 发言时的发言内容；未轮到发言的签到为 None。
+    /// 轮到该 Agent 发言时的发言内容；听众签到为 None。
     pub content: Option<String>,
     /// 主持人专用：结束会议。非主持人传了会被忽略。
     pub end_meeting: bool,
@@ -61,43 +68,120 @@ pub struct MeetingConfig {
     /// (agent_id, 名字)，同时是发言顺序：发起人在前，其余按创建顺序。
     pub participants: Vec<(String, String)>,
     pub max_speeches: u32,
+    /// 入场前处于休眠状态的与会者，散会时还原成休眠而不是 Idle。
+    pub sleeping_before: HashSet<String>,
 }
 
 struct Waiter {
     reply: oneshot::Sender<serde_json::Value>,
+    /// 签到携带的发言内容；被采纳后置 None，避免下次被点名时重复采纳。
     content: Option<String>,
     end_meeting: bool,
 }
 
+/// 从 `from` 的下一位开始，找第一个未缺席的与会者下标（可能绕回 `from`
+/// 自己——全场只剩一个人时它就自己连讲）；全员缺席返回 None。
+fn next_present(cfg: &MeetingConfig, absent: &HashSet<String>, from: usize) -> Option<usize> {
+    let n = cfg.participants.len();
+    for step in 1..=n {
+        let idx = (from + step) % n;
+        if !absent.contains(&cfg.participants[idx].0) {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+/// 放行一个与会者去发言：补发它按 `seen` 进度错过的全部发言（不含它自己
+/// 说过的），并把它的进度推到最新。
+fn your_turn_payload(
+    cfg: &MeetingConfig,
+    seen: &mut HashMap<String, usize>,
+    agent_id: &str,
+    transcript: &[(String, String, String)],
+    wrap_up_requested: bool,
+) -> serde_json::Value {
+    let idx = seen.get(agent_id).copied().unwrap_or(0);
+    let new_speeches: Vec<_> = transcript[idx..]
+        .iter()
+        .filter(|(sid, _, _)| sid != agent_id)
+        .map(|(_, name, content)| serde_json::json!({ "speaker": name, "content": content }))
+        .collect();
+    seen.insert(agent_id.to_string(), transcript.len());
+    let wrap_up_hint = if wrap_up_requested {
+        "会议已达到发言上限：请在这次发言中总结会议结论，并同时把 end_meeting 设为 true 结束会议。"
+    } else {
+        ""
+    };
+    serde_json::json!({
+        "status": "your_turn",
+        "meetingId": cfg.meeting_id,
+        "topic": cfg.topic,
+        "newSpeeches": new_speeches,
+        "speechCount": transcript.len(),
+        "instruction": format!(
+            "轮到你发言了。请立即再次调用 workspace_meeting_checkin（meeting_id 填 \"{}\"），把你对议题的发言写进 content 参数。{}",
+            cfg.meeting_id, wrap_up_hint
+        ),
+    })
+}
+
 pub async fn run_coordinator(app_handle: AppHandle, cfg: MeetingConfig, mut rx: mpsc::Receiver<MeetingCheckIn>) {
+    // 已签到、正挂起等待的与会者（含刚交完发言的人）。
     let mut waiting: HashMap<String, Waiter> = HashMap::new();
     let mut absent: HashSet<String> = HashSet::new();
     // (speaker_id, speaker_name, 发言内容)
     let mut transcript: Vec<(String, String, String)> = Vec::new();
-    // 每个与会者已收到的发言进度（transcript 下标）；缺席补签的人靠它补收错过的发言。
+    // 每个与会者已收到的发言进度（transcript 下标）；点名/散会时靠它补发。
     let mut seen: HashMap<String, usize> = cfg.participants.iter().map(|(id, _)| (id.clone(), 0)).collect();
-    // 本轮被指定发言的人（participants 下标）；第一轮是发起人的开场发言。
+    // 当前被点名发言的人（participants 下标）；第一轮是发起人的开场发言。
     let mut speaker_pos: usize = 0;
     let mut wrap_up_requested = false;
     let mut end_reason: Option<String> = None;
 
     while end_reason.is_none() {
-        // ---- 集合阶段：等所有未缺席的与会者签到 ----
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(CYCLE_TIMEOUT_SECS);
+        let (speaker_id, speaker_name) = cfg.participants[speaker_pos].clone();
+        let mut released_this_turn = false;
+        let mut speech: Option<String> = None;
+
+        // ---- 取得发言人的发言（或判定它缺席/弃权）----
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(TURN_TIMEOUT_SECS);
         loop {
-            let all_present = cfg.participants.iter().all(|(id, _)| absent.contains(id) || waiting.contains_key(id));
-            if all_present && !waiting.is_empty() {
+            // 挂起中的发言人：有现成发言就直接采纳；没有就放行它、请它发言。
+            let mut needs_release = false;
+            if let Some(w) = waiting.get_mut(&speaker_id) {
+                match w.content.take().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
+                    Some(text) => {
+                        speech = Some(text);
+                    }
+                    None => needs_release = true,
+                }
+            }
+            if speech.is_some() {
                 break;
             }
+            if needs_release {
+                if released_this_turn {
+                    // 放行过一次却交回了空发言：视为弃权。不再反复放行——那只会
+                    // 让一个不肯发言的模型无限空转烧 API 调用，发言权顺延即可。
+                    insert_workspace_log(&app_handle, &cfg.workspace_id, Some(speaker_id.clone()), "meeting",
+                        format!("「{}」放弃本轮发言，发言权顺延", speaker_name)).await;
+                    break;
+                }
+                released_this_turn = true;
+                if let Some(w) = waiting.remove(&speaker_id) {
+                    let payload = your_turn_payload(&cfg, &mut seen, &speaker_id, &transcript, wrap_up_requested);
+                    let _ = w.reply.send(payload);
+                }
+                continue;
+            }
+            // 发言人不在场（还没签到 / 被放行后尚未交回发言）：等它，
+            // 等待期间照常接纳其他人的签到挂起。
             tokio::select! {
                 _ = tokio::time::sleep_until(deadline) => {
-                    for (id, name) in &cfg.participants {
-                        if !waiting.contains_key(id) && !absent.contains(id) {
-                            absent.insert(id.clone());
-                            insert_workspace_log(&app_handle, &cfg.workspace_id, Some(id.clone()), "meeting",
-                                format!("「{}」未在时限内签到，本场会议标记缺席", name)).await;
-                        }
-                    }
+                    absent.insert(speaker_id.clone());
+                    insert_workspace_log(&app_handle, &cfg.workspace_id, Some(speaker_id.clone()), "meeting",
+                        format!("「{}」未在时限内签到发言，本场会议标记缺席，发言权顺延", speaker_name)).await;
                     break;
                 }
                 msg = rx.recv() => match msg {
@@ -119,30 +203,21 @@ pub async fn run_coordinator(app_handle: AppHandle, cfg: MeetingConfig, mut rx: 
         if end_reason.is_some() {
             break;
         }
-        if waiting.is_empty() {
-            end_reason = Some("所有与会者均缺席".to_string());
-            break;
-        }
 
-        // ---- 记录本轮发言 ----
-        let (speaker_id, speaker_name) = cfg.participants[speaker_pos].clone();
-        let chair_wants_end = waiting.get(&cfg.initiator_id).map(|w| w.end_meeting).unwrap_or(false);
-
-        let speech = waiting
-            .get(&speaker_id)
-            .and_then(|w| w.content.clone())
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+        // ---- 记录本轮发言 + 静默落库 ----
         if let Some(text) = &speech {
             transcript.push((speaker_id.clone(), speaker_name.clone(), text.clone()));
             send_workspace_message_silent(&app_handle, &cfg.workspace_id, &speaker_id, "all",
                 &format!("【会议发言 · {}】{}", cfg.topic, text)).await;
         }
-        // 主持人不在发言轮却带着结束陈词来散会：陈词也记入纪要。
+
+        // ---- 结束条件 ----
+        let chair_wants_end = waiting.get(&cfg.initiator_id).map(|w| w.end_meeting).unwrap_or(false);
+        // 主持人不在发言轮却带着结束陈词来散会（比如缺席后补签到）：陈词也记入纪要。
         if chair_wants_end && speaker_id != cfg.initiator_id {
             let closing = waiting
-                .get(&cfg.initiator_id)
-                .and_then(|w| w.content.clone())
+                .get_mut(&cfg.initiator_id)
+                .and_then(|w| w.content.take())
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty());
             if let Some(text) = closing {
@@ -165,7 +240,11 @@ pub async fn run_coordinator(app_handle: AppHandle, cfg: MeetingConfig, mut rx: 
             break;
         }
         if wrap_up_requested && speaker_id == cfg.initiator_id {
-            end_reason = Some("会议达到发言上限，主持人总结后结束".to_string());
+            end_reason = Some(if speech.is_some() {
+                "会议达到发言上限，主持人总结后结束".to_string()
+            } else {
+                "会议达到发言上限（主持人未作总结，自动结束）".to_string()
+            });
             break;
         }
         if cap_reached && chair_absent {
@@ -179,63 +258,17 @@ pub async fn run_coordinator(app_handle: AppHandle, cfg: MeetingConfig, mut rx: 
             wrap_up_requested = true;
             speaker_pos = cfg.participants.iter().position(|(id, _)| *id == cfg.initiator_id).unwrap_or(0);
         } else {
-            let n = cfg.participants.len();
-            let mut next = (speaker_pos + 1) % n;
-            for _ in 0..n {
-                if !absent.contains(&cfg.participants[next].0) {
+            match next_present(&cfg, &absent, speaker_pos) {
+                Some(next) => speaker_pos = next,
+                None => {
+                    end_reason = Some("所有与会者均缺席".to_string());
                     break;
                 }
-                next = (next + 1) % n;
             }
-            speaker_pos = next;
-        }
-        let (next_id, next_name) = cfg.participants[speaker_pos].clone();
-
-        // ---- 放行：把新发言作为工具结果发给每个等待中的与会者 ----
-        for (aid, w) in waiting.drain() {
-            let idx = seen.get(&aid).copied().unwrap_or(0);
-            let new_speeches: Vec<_> = transcript[idx..]
-                .iter()
-                .filter(|(sid, _, _)| *sid != aid)
-                .map(|(_, name, content)| serde_json::json!({ "speaker": name, "content": content }))
-                .collect();
-            seen.insert(aid.clone(), transcript.len());
-            let payload = if aid == next_id {
-                let wrap_up_hint = if wrap_up_requested {
-                    "会议已达到发言上限：请在这次发言中总结会议结论，并同时把 end_meeting 设为 true 结束会议。"
-                } else {
-                    ""
-                };
-                serde_json::json!({
-                    "status": "your_turn",
-                    "meetingId": cfg.meeting_id,
-                    "topic": cfg.topic,
-                    "newSpeeches": new_speeches,
-                    "speechCount": transcript.len(),
-                    "instruction": format!(
-                        "轮到你发言了。请立即再次调用 workspace_meeting_checkin（meeting_id 填 \"{}\"），把你对议题的发言写进 content 参数。{}",
-                        cfg.meeting_id, wrap_up_hint
-                    ),
-                })
-            } else {
-                serde_json::json!({
-                    "status": "listening",
-                    "meetingId": cfg.meeting_id,
-                    "topic": cfg.topic,
-                    "newSpeeches": new_speeches,
-                    "speechCount": transcript.len(),
-                    "nextSpeaker": next_name,
-                    "instruction": format!(
-                        "请听取以上发言。下一位发言人是「{}」。请立即再次调用 workspace_meeting_checkin（meeting_id 填 \"{}\"，content 留空）签到等待。",
-                        next_name, cfg.meeting_id
-                    ),
-                })
-            };
-            let _ = w.reply.send(payload);
         }
     }
 
-    // ---- 收尾：给仍在等待的与会者发会议结束结果，注销会议，复位状态 ----
+    // ---- 收尾：给仍在等待的与会者发会议结束结果，注销会议，还原状态 ----
     let reason = end_reason.unwrap_or_else(|| "会议结束".to_string());
     let transcript_json: Vec<_> = transcript
         .iter()
@@ -271,7 +304,8 @@ pub async fn run_coordinator(app_handle: AppHandle, cfg: MeetingConfig, mut rx: 
     }
     for (id, _) in &cfg.participants {
         if matches!(load_agent(&app_handle, id).await, Ok(Some(a)) if a.status == AgentStatus::Meeting) {
-            set_agent_status(&app_handle, id, AgentStatus::Idle).await;
+            let restore = if cfg.sleeping_before.contains(id) { AgentStatus::Sleeping } else { AgentStatus::Idle };
+            set_agent_status(&app_handle, id, restore).await;
         }
     }
     insert_workspace_log(&app_handle, &cfg.workspace_id, Some(cfg.initiator_id.clone()), "meeting",

--- a/src-tauri/src/workspace_smoke_test.rs
+++ b/src-tauri/src/workspace_smoke_test.rs
@@ -184,12 +184,11 @@ pub async fn run(app_handle: AppHandle) {
             let Some(question_id) = value.get("questionId").and_then(|v| v.as_str()) else { return };
             log::info!("[smoke_test] 监听到提问事件，自动代用户回答: {}", question_id);
             let pending = handle.state::<PendingQuestions>();
-            let db_state = handle.state::<DbState>();
             if let Err(e) = crate::workspace::commands::workspace_resolve_question(
                 question_id.to_string(),
                 "可以，辛苦了，批准休息。".to_string(),
                 pending,
-                db_state,
+                handle.clone(),
             )
             .await
             {
@@ -212,8 +211,7 @@ pub async fn run(app_handle: AppHandle) {
             log::info!("[smoke_test] 监听到休眠申请事件: {}，给主 Agent 30s 自行批准的机会", request_id);
             tokio::time::sleep(Duration::from_secs(30)).await;
             let pending = handle.state::<PendingSleepRequests>();
-            let db_state = handle.state::<DbState>();
-            match crate::workspace::commands::workspace_resolve_sleep_request(request_id.clone(), true, pending, db_state).await {
+            match crate::workspace::commands::workspace_resolve_sleep_request(request_id.clone(), true, pending, handle.clone()).await {
                 Ok(()) => log::info!("[smoke_test] 主 Agent 30s 内没批准，已通过用户代为批准覆盖: {}", request_id),
                 Err(_) => log::info!("[smoke_test] 主 Agent 已经自己处理过这个休眠申请: {}", request_id),
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0-beta.11",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -17,7 +17,7 @@
 
 <script setup lang="ts">
 // 导入 Vue 相关功能
-import { computed, onMounted, onBeforeUnmount } from "vue";
+import { computed, onMounted, onBeforeUnmount, watch } from "vue";
 
 // 导入 Vue Router 相关功能
 import { useRoute, useRouter } from "vue-router";
@@ -28,6 +28,7 @@ import { useNotification } from "naive-ui";
 // 导入 Store
 import { useSettingsStore } from "@/stores/settings";
 import { useChatStore } from "@/stores/chat";
+import { useWorkspaceStore } from "@/stores/workspace";
 
 // 导入快捷键匹配工具
 import { eventMatchesAccelerator } from "@/utils/hotkey";
@@ -51,6 +52,20 @@ const settings = useSettingsStore();
 
 // 聊天 Store
 const chat = useChatStore();
+
+// 协作团队 Store：事件监听在这里（App 布局层）注册，而不是等用户第一次打开
+// 协作团队页面——否则 Agent 在别的页面提问/申请审批时整个应用毫无反应，
+// 后端只能干等 10 分钟超时。
+const workspace = useWorkspaceStore();
+
+// 所有工作组加总的待人工处理事项数：侧边栏徽标 + 新增时左下角弹提醒。
+const workspacePendingCount = computed(
+  () =>
+    workspace.proposals.length +
+    workspace.sleepRequests.length +
+    workspace.questions.length +
+    workspace.toolApprovals.length
+);
 
 // 当前激活的菜单项
 const activeKey = computed(() => route.name as string);
@@ -96,12 +111,26 @@ const handleNewSessionHotkey = (e: KeyboardEvent) => {
 // 通知 API (供更新提示弹窗使用)
 const notification = useNotification();
 
-onMounted(() => {
+// 待处理事项新增、且用户没停在协作团队页面时，左下角弹一条提醒（在页面上
+// 时卡片本身就是提醒，不重复弹）。
+watch(workspacePendingCount, (count, prev) => {
+  if (count > prev && route.name !== "AgentTeam") {
+    notification.info({
+      title: "协作团队有新的待处理事项",
+      content: `当前共有 ${count} 件事项等待你处理（Agent 提议 / 休眠申请 / 提问 / 工具审批）。`,
+      duration: 8000,
+    });
+  }
+});
+
+onMounted(async () => {
   window.addEventListener("keydown", handleNewSessionHotkey);
   // 延迟几秒再检测更新，避免和启动初始化抢时间
   setTimeout(() => {
     void checkForAppUpdate(notification);
   }, 3000);
+  // 全局注册协作团队事件监听（幂等，AgentTeamView 里再调用也不会重复注册）
+  await workspace.initListeners();
 });
 
 onBeforeUnmount(() => {
@@ -148,6 +177,10 @@ onBeforeUnmount(() => {
         >
           <span class="nav-index">{{ String(index + 1).padStart(2, "0") }}</span>
           <span class="nav-name">{{ item.name }}</span>
+          <span
+            v-if="item.key === 'AgentTeam' && workspacePendingCount > 0"
+            class="nav-badge"
+          >{{ workspacePendingCount > 99 ? "99+" : workspacePendingCount }}</span>
           <span class="nav-label">{{ item.label }}</span>
         </button>
       </nav>
@@ -335,6 +368,22 @@ onBeforeUnmount(() => {
   text-transform: uppercase;
   color: $ink-faint;
   transition: color $duration $ease;
+}
+
+// 协作团队待处理事项计数徽标：黑底白字直角小方块，激活项（黑底）上反转。
+.nav-badge {
+  font-family: $font-mono;
+  font-size: 0.65rem;
+  line-height: 1;
+  padding: 2px 5px;
+  background: $ink;
+  color: $bg;
+  flex-shrink: 0;
+}
+
+.nav-item.is-active .nav-badge {
+  background: $bg;
+  color: $ink;
 }
 
 // ---------- 底部装饰 ----------

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -150,6 +150,8 @@ export interface AgentProposalEvent {
   proposedByAgentId: string;
   proposedByAgentName: string;
   draft: CreateAgentRequest;
+  /** 事项发起时间，用于展示"还剩多久超时"的倒计时。 */
+  createdAt: number;
 }
 
 export interface SleepRequestEvent {
@@ -158,6 +160,7 @@ export interface SleepRequestEvent {
   agentId: string;
   agentName: string;
   reason: string;
+  createdAt: number;
 }
 
 export interface QuestionEvent {
@@ -166,6 +169,7 @@ export interface QuestionEvent {
   agentId: string;
   agentName: string;
   question: string;
+  createdAt: number;
 }
 
 interface AgentStatusEvent {
@@ -180,6 +184,7 @@ export interface ToolApprovalEvent {
   agentName: string;
   toolName: string;
   arguments: Record<string, unknown>;
+  createdAt: number;
 }
 
 /** 持久化的待处理事项，用于补齐"页面没开着 / App 重启前发生"而错过的一次性事件。 */
@@ -207,9 +212,10 @@ export const useWorkspaceStore = defineStore("workspace", () => {
   const messages = ref<WorkspaceMessage[]>([]);
   const logs = ref<WorkspaceLogEntry[]>([]);
 
-  // 主 Agent 提议创建子 Agent / 申请休眠 / 向用户提问，都需要用户在前端处理。
-  // 不按当前选中的工作组过滤 -- 后端只是触发一次性事件，没有"列出所有待处理事项"
-  // 的命令，错过事件就再也找不回来了，所以哪怕用户当下没看着对应工作组，也要留着。
+  // 主 Agent 提议创建子 Agent / 申请休眠 / 向用户提问 / 高危工具审批，都需要
+  // 用户在前端处理。不按当前选中的工作组过滤——哪怕用户当下没看着对应工作组
+  // 也要留着（全局徽标要统计所有工作组的待办数）；错过实时事件也没关系，
+  // 事项已持久化，selectWorkspace 时会用 loadPendingEvents 补拉回来。
   const proposals = ref<AgentProposalEvent[]>([]);
   const sleepRequests = ref<SleepRequestEvent[]>([]);
   const questions = ref<QuestionEvent[]>([]);
@@ -219,6 +225,10 @@ export const useWorkspaceStore = defineStore("workspace", () => {
   const inactiveAgentNotices = ref<AgentInactiveEvent[]>([]);
 
   const currentWorkspace = computed(() => workspaces.value.find((w) => w.id === currentWorkspaceId.value) ?? null);
+
+  // 任务清单变更信号：视图层 watch tasksVersion，命中当前选中 Agent 时重拉。
+  const tasksVersion = ref(0);
+  const lastTaskUpdateAgentId = ref<string | null>(null);
 
   let unlistenFns: UnlistenFn[] = [];
 
@@ -262,6 +272,21 @@ export const useWorkspaceStore = defineStore("workspace", () => {
       listen<ToolApprovalEvent>("workspace://tool-approval", (e) => {
         console.log(`[Workspace] 工具调用审批请求: approvalId=${e.payload.approvalId} agent=${e.payload.agentName} tool=${e.payload.toolName}`);
         toolApprovals.value.push(e.payload);
+      }),
+      // 待处理事项被"别人"解决时（主 Agent 用工具批准了休眠、10 分钟超时
+      // 自动收场、应用判定过期），把还挂在界面上的卡片撤掉——否则用户对着
+      // 一张已经处理完的卡片再点一次，只会收到一句"不存在或已被处理"。
+      listen<{ id: string }>("workspace://pending-resolved", (e) => {
+        const id = e.payload.id;
+        proposals.value = proposals.value.filter((p) => p.proposalId !== id);
+        sleepRequests.value = sleepRequests.value.filter((r) => r.requestId !== id);
+        questions.value = questions.value.filter((q) => q.questionId !== id);
+        toolApprovals.value = toolApprovals.value.filter((t) => t.approvalId !== id);
+      }),
+      // Agent 自己增删改了任务清单：通知视图层重新拉取，别让用户看着旧清单。
+      listen<{ agentId: string }>("workspace://tasks-updated", (e) => {
+        lastTaskUpdateAgentId.value = e.payload.agentId;
+        tasksVersion.value += 1;
       }),
       listen<AgentInactiveEvent>("workspace://agent-inactive", (e) => {
         console.log(`[Workspace] Agent 未在运行: agentId=${e.payload.agentId} name=${e.payload.agentName}`);
@@ -343,15 +368,16 @@ export const useWorkspaceStore = defineStore("workspace", () => {
     for (const e of events) {
       if (e.kind === "proposal" && !proposals.value.some((p) => p.proposalId === e.id)) {
         const draft = e.payload.draft as CreateAgentRequest;
-        proposals.value.push({ proposalId: e.id, workspaceId: e.workspaceId, proposedByAgentId: e.agentId, proposedByAgentName: e.agentName, draft });
+        proposals.value.push({ proposalId: e.id, workspaceId: e.workspaceId, proposedByAgentId: e.agentId, proposedByAgentName: e.agentName, draft, createdAt: e.createdAt });
       } else if (e.kind === "sleep" && !sleepRequests.value.some((r) => r.requestId === e.id)) {
-        sleepRequests.value.push({ requestId: e.id, workspaceId: e.workspaceId, agentId: e.agentId, agentName: e.agentName, reason: (e.payload.reason as string) ?? "" });
+        sleepRequests.value.push({ requestId: e.id, workspaceId: e.workspaceId, agentId: e.agentId, agentName: e.agentName, reason: (e.payload.reason as string) ?? "", createdAt: e.createdAt });
       } else if (e.kind === "question" && !questions.value.some((q) => q.questionId === e.id)) {
-        questions.value.push({ questionId: e.id, workspaceId: e.workspaceId, agentId: e.agentId, agentName: e.agentName, question: (e.payload.question as string) ?? "" });
+        questions.value.push({ questionId: e.id, workspaceId: e.workspaceId, agentId: e.agentId, agentName: e.agentName, question: (e.payload.question as string) ?? "", createdAt: e.createdAt });
       } else if (e.kind === "tool_approval" && !toolApprovals.value.some((t) => t.approvalId === e.id)) {
         toolApprovals.value.push({
           approvalId: e.id, workspaceId: e.workspaceId, agentId: e.agentId, agentName: e.agentName,
           toolName: (e.payload.toolName as string) ?? "", arguments: (e.payload.arguments as Record<string, unknown>) ?? {},
+          createdAt: e.createdAt,
         });
       }
     }
@@ -430,6 +456,12 @@ export const useWorkspaceStore = defineStore("workspace", () => {
     await invoke("workspace_set_task_done", { taskId, done });
   };
 
+  /** 用户直接编辑/清空某个 Agent 的工作备忘（scratchpad）；传空字符串即清空。 */
+  const setScratchpad = async (agentId: string, content: string) => {
+    await invoke("workspace_set_scratchpad", { agentId, content });
+    await loadAgents();
+  };
+
   /** 这个 Agent 最近一条错误日志的内容——用于在花名册上直接展示出错原因，
    *  而不是只有一个"异常"标签、需要用户自己去时间线里翻。 */
   const latestErrorFor = (agentId: string): string | null => {
@@ -494,7 +526,18 @@ export const useWorkspaceStore = defineStore("workspace", () => {
     resumeAgent,
     listAgentTasks,
     setTaskDone,
+    setScratchpad,
+    tasksVersion,
+    lastTaskUpdateAgentId,
     latestErrorFor,
     agentName,
   };
+},
+{
+  persist: {
+    key: "baiyu-aispace-workspace",
+    // 只记住"上次看的是哪个工作组"，重启后不用重新选一遍；agents/messages
+    // 等列表都是选中时现拉的，持久化它们只会带来一屏过期数据。
+    paths: ["currentWorkspaceId"],
+  },
 });

--- a/src/views/AgentTeamView.vue
+++ b/src/views/AgentTeamView.vue
@@ -10,20 +10,20 @@
   - Agent 列表 + 状态展示，手动添加/删除 Agent
   - 单个 Agent 的对话面板（复用 ChatMessage.vue）
   - 整个工作组的活动时间线（消息 + 操作日志合并展示）
-  - 主 Agent 提议创建子 Agent / 申请休眠 / 向用户提问 三类待处理事项的确认卡片
+  - Agent 提议创建子 Agent / 申请休眠 / 向用户提问 / 高危工具审批 四类待处理事项的确认卡片
 -->
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, watch } from "vue";
+import { ref, reactive, computed, nextTick, onBeforeUnmount, onMounted, watch } from "vue";
 import { useRouter } from "vue-router";
 import {
   NButton, NIcon, NSpace, NSelect, NEmpty, NModal, NForm, NFormItem, NInput, NInputNumber,
   NRadioGroup, NRadio, NCheckboxGroup, NCheckbox, NCard, NGrid, NGi, NList, NListItem, NThing,
-  NTag, NTimeline, NTimelineItem, NPopconfirm, NSwitch, NTooltip, useMessage,
+  NTag, NText, NTimeline, NTimelineItem, NPopconfirm, NSwitch, NTooltip, useMessage,
 } from "naive-ui";
 import {
   Add, TrashOutline, EnterOutline, AlarmOutline, PencilOutline, MegaphoneOutline,
-  PauseOutline, PlayOutline, RefreshOutline,
+  PauseOutline, PlayOutline, RefreshOutline, DocumentTextOutline,
 } from "@vicons/ionicons5";
 
 import ChatMessage from "@/components/ChatMessage.vue";
@@ -330,6 +330,54 @@ const handleToggleTask = async (taskId: string, done: boolean) => {
   }
 };
 
+// Agent 自己增删改任务清单时后端会发 tasks-updated 事件（store 里把它变成
+// tasksVersion 递增）；命中当前正看着的 Agent 就自动重拉，不用手动点刷新。
+watch(
+  () => workspace.tasksVersion,
+  () => {
+    if (workspace.lastTaskUpdateAgentId === selectedAgentId.value) void loadAgentTasks();
+  }
+);
+
+// ============ 选中 Agent 的工作备忘（scratchpad） ============
+
+const showScratchpadModal = ref(false);
+const scratchpadDraft = ref("");
+
+const openScratchpadModal = async () => {
+  if (!selectedAgentId.value) return;
+  try {
+    // 先重拉一次 Agent 列表，拿到 Agent 最近写入的备忘，而不是页面加载时的旧快照。
+    await workspace.loadAgents();
+  } catch {
+    // 拉取失败就用现有快照，弹窗照常打开
+  }
+  scratchpadDraft.value = selectedAgent.value?.scratchpad ?? "";
+  showScratchpadModal.value = true;
+};
+
+const handleSaveScratchpad = async () => {
+  if (!selectedAgentId.value) return;
+  try {
+    await workspace.setScratchpad(selectedAgentId.value, scratchpadDraft.value);
+    showScratchpadModal.value = false;
+    message.success("备忘已保存");
+  } catch (e) {
+    message.error(`保存失败: ${e}`);
+  }
+};
+
+const handleClearScratchpad = async () => {
+  if (!selectedAgentId.value) return;
+  try {
+    await workspace.setScratchpad(selectedAgentId.value, "");
+    scratchpadDraft.value = "";
+    message.success("备忘已清空");
+  } catch (e) {
+    message.error(`清空失败: ${e}`);
+  }
+};
+
 const statusMeta: Record<AgentStatus, { label: string; type: "default" | "success" | "warning" | "error" | "info" }> = {
   idle: { label: "空闲", type: "default" },
   running: { label: "运行中", type: "success" },
@@ -369,6 +417,47 @@ const handleSendMessage = async () => {
   }
 };
 
+// Enter 发送、Shift+Enter 换行。必须用 keydown 且判 isComposing：中文输入法
+// 里敲回车是在确认候选字，keyup.enter 分不清这两种回车，字没打完消息就飞出
+// 去了（keyCode 229 是老 WebView 里输入法组合键的兜底判据）。
+const handleMessageKeydown = (e: KeyboardEvent) => {
+  if (e.shiftKey || e.isComposing || e.keyCode === 229) return;
+  e.preventDefault();
+  void handleSendMessage();
+};
+
+// ============ 消息 / 时间线自动滚动 ============
+
+// 新内容默认跟随滚动到底部；用户主动向上翻阅（离底部超过 40px）时暂停跟随，
+// 翻回底部后恢复——别在用户看历史时把视口拽走。
+const messageScrollRef = ref<HTMLElement | null>(null);
+const timelineScrollRef = ref<HTMLElement | null>(null);
+const messageStick = ref(true);
+const timelineStick = ref(true);
+
+const nearBottom = (el: HTMLElement) => el.scrollTop + el.clientHeight >= el.scrollHeight - 40;
+const handleMessageScroll = () => {
+  if (messageScrollRef.value) messageStick.value = nearBottom(messageScrollRef.value);
+};
+const handleTimelineScroll = () => {
+  if (timelineScrollRef.value) timelineStick.value = nearBottom(timelineScrollRef.value);
+};
+const scrollToBottom = async (el: { value: HTMLElement | null }) => {
+  await nextTick();
+  if (el.value) el.value.scrollTop = el.value.scrollHeight;
+};
+
+watch(
+  () => agentMessages.value.length,
+  () => {
+    if (messageStick.value) void scrollToBottom(messageScrollRef);
+  }
+);
+watch(selectedAgentId, () => {
+  messageStick.value = true;
+  void scrollToBottom(messageScrollRef);
+});
+
 // ============ 活动时间线（消息 + 日志合并） ============
 
 const logKindLabels: Record<string, string> = {
@@ -386,6 +475,7 @@ const logKindLabels: Record<string, string> = {
   paused: "手动暂停",
   resumed: "恢复运行",
   tool_approval: "工具调用审批",
+  pending_expired: "待处理事项过期",
 };
 
 const logTimelineType = (kind: string): "default" | "success" | "warning" | "error" | "info" => {
@@ -401,25 +491,77 @@ const logTitle = (l: WorkspaceLogEntry) => {
   return `${agent ? agent + " · " : ""}${logKindLabels[l.kind] ?? l.kind}`;
 };
 
+// 时间线过滤：工具调用/系统事件一多，真正的对话会被刷得看不见。
+type TimelineCategory = "message" | "tool" | "system" | "error";
+const timelineFilter = ref<"all" | TimelineCategory>("all");
+const timelineFilterOptions = [
+  { label: "全部", value: "all" },
+  { label: "仅消息", value: "message" },
+  { label: "工具调用", value: "tool" },
+  { label: "系统事件", value: "system" },
+  { label: "错误", value: "error" },
+];
+const logCategory = (kind: string): TimelineCategory => {
+  if (kind === "error" || kind === "auto_paused") return "error";
+  if (kind === "tool_call" || kind === "tool_approval") return "tool";
+  return "system";
+};
+
+/** tool_call 日志带着完整 JSON 参数，原样放进时间线会刷屏；截断展示，
+ *  完整参数仍在应用日志和数据库里。 */
+const clipContent = (s: string, max = 160) => (s.length > max ? `${s.slice(0, max)} …` : s);
+
 const timeline = computed(() => {
-  const fromMessages = workspace.messages.map((m) => ({
-    id: `msg-${m.id}`,
-    createdAt: m.createdAt,
-    type: "success" as const,
-    title: `${workspace.agentName(m.fromAgentId)} → ${workspace.agentName(m.toAgentId)}`,
-    content: m.content,
-  }));
-  const fromLogs = workspace.logs.map((l) => ({
-    id: `log-${l.id}`,
-    createdAt: l.createdAt,
-    type: logTimelineType(l.kind),
-    title: logTitle(l),
-    content: l.content,
-  }));
+  const fromMessages =
+    timelineFilter.value === "all" || timelineFilter.value === "message"
+      ? workspace.messages.map((m) => ({
+          id: `msg-${m.id}`,
+          createdAt: m.createdAt,
+          type: "success" as const,
+          title: `${workspace.agentName(m.fromAgentId)} → ${workspace.agentName(m.toAgentId)}`,
+          content: m.content,
+        }))
+      : [];
+  const fromLogs = workspace.logs
+    .filter((l) => timelineFilter.value === "all" || logCategory(l.kind) === timelineFilter.value)
+    .map((l) => ({
+      id: `log-${l.id}`,
+      createdAt: l.createdAt,
+      type: logTimelineType(l.kind),
+      title: logTitle(l),
+      content: l.kind === "tool_call" ? clipContent(l.content) : l.content,
+    }));
   return [...fromMessages, ...fromLogs].sort((a, b) => a.createdAt - b.createdAt);
 });
 
-const formatTime = (ts: number) => new Date(ts).toLocaleTimeString();
+watch(
+  () => timeline.value.length,
+  () => {
+    if (timelineStick.value) void scrollToBottom(timelineScrollRef);
+  }
+);
+
+// 跨天的记录只显示时分秒会分不清是哪天的——非当天的补上"月/日"。
+const formatTime = (ts: number) => {
+  const d = new Date(ts);
+  const now = new Date();
+  const sameDay = d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
+  return sameDay ? d.toLocaleTimeString() : `${d.getMonth() + 1}/${d.getDate()} ${d.toLocaleTimeString()}`;
+};
+
+// ============ 待处理卡片的超时倒计时 ============
+
+// 后端所有待人工处理的等待都是 10 分钟超时（PROPOSAL_TIMEOUT_SECS）。
+const PENDING_TIMEOUT_MS = 10 * 60 * 1000;
+const nowTick = ref(Date.now());
+let nowTimer: number | undefined;
+
+const pendingCountdown = (createdAt: number) => {
+  const remain = createdAt + PENDING_TIMEOUT_MS - nowTick.value;
+  if (remain <= 0) return "已超时，即将自动收场";
+  const minutes = Math.ceil(remain / 60000);
+  return `约 ${minutes} 分钟后超时`;
+};
 
 // ============ 定时任务（跳转到独立页面） ============
 
@@ -529,15 +671,41 @@ const handleAnswer = async (questionId: string) => {
   }
 };
 
+// 同 handleMessageKeydown：Enter 提交、Shift+Enter 换行、输入法确认候选不误提交。
+const handleAnswerKeydown = (questionId: string, e: KeyboardEvent) => {
+  if (e.shiftKey || e.isComposing || e.keyCode === 229) return;
+  e.preventDefault();
+  void handleAnswer(questionId);
+};
+
 // ============ 初始化 ============
 
 onMounted(async () => {
-  // 事件监听只在第一次挂载时注册，且不会在组件卸载时取消 -- 主 Agent 的提议/
-  // 休眠申请/提问都是一次性事件，没有"补查历史"的命令，错过了就再也找不回来，
-  // 所以让它们在整个 App 生命周期里持续监听，而不是只在这个页面打开时才听。
+  // 事件监听正常情况下已由 Layout 在应用启动时全局注册（这样 Agent 在别的
+  // 页面提问/申请审批时也有徽标和左下角提醒）；这里再调用一次只是幂等兜底。
   await workspace.initListeners();
   await workspace.listWorkspaces();
+
+  // 恢复上次选中的工作组（currentWorkspaceId 已持久化），把它的数据拉回来；
+  // 工作组可能已在别处被删除，找不到就清空选择。
+  const savedId = workspace.currentWorkspaceId;
+  if (savedId) {
+    if (workspace.workspaces.some((w) => w.id === savedId)) {
+      await workspace.selectWorkspace(savedId);
+    } else {
+      workspace.currentWorkspaceId = null;
+    }
+  }
+
+  nowTimer = window.setInterval(() => {
+    nowTick.value = Date.now();
+  }, 15000);
+
   await Promise.all([mcp.loadServers(), kb.loadKnowledgeBases(), skills.loadSkills()]);
+});
+
+onBeforeUnmount(() => {
+  if (nowTimer !== undefined) window.clearInterval(nowTimer);
 });
 </script>
 
@@ -546,7 +714,9 @@ onMounted(async () => {
     <div class="page-header enter-up">
       <div class="header-left">
         <span class="eyebrow">Agents</span>
-        <h1 class="page-title">协作团队</h1>
+        <h1 class="page-title">
+          协作团队
+        </h1>
       </div>
       <n-space>
         <n-select
@@ -556,14 +726,29 @@ onMounted(async () => {
           style="width: 220px"
           @update:value="handleSelectWorkspace"
         />
-        <n-button type="primary" @click="showCreateWorkspaceModal = true">
-          <template #icon><n-icon><Add /></n-icon></template>
+        <n-button
+          type="primary"
+          @click="showCreateWorkspaceModal = true"
+        >
+          <template #icon>
+            <n-icon><Add /></n-icon>
+          </template>
           新建工作组
         </n-button>
-        <n-popconfirm v-if="workspace.currentWorkspace" positive-text="删除" negative-text="取消" @positive-click="handleDeleteWorkspace">
+        <n-popconfirm
+          v-if="workspace.currentWorkspace"
+          positive-text="删除"
+          negative-text="取消"
+          @positive-click="handleDeleteWorkspace"
+        >
           <template #trigger>
-            <n-button type="error" ghost>
-              <template #icon><n-icon><TrashOutline /></n-icon></template>
+            <n-button
+              type="error"
+              ghost
+            >
+              <template #icon>
+                <n-icon><TrashOutline /></n-icon>
+              </template>
               删除当前工作组
             </n-button>
           </template>
@@ -572,100 +757,257 @@ onMounted(async () => {
       </n-space>
     </div>
 
-    <n-empty v-if="!workspace.currentWorkspaceId" description="选择或新建一个工作组开始" style="margin-top: 120px" />
+    <n-empty
+      v-if="!workspace.currentWorkspaceId"
+      description="选择或新建一个工作组开始"
+      style="margin-top: 120px"
+    />
 
     <template v-else>
-      <div v-if="workspace.proposals.length || workspace.sleepRequests.length || workspace.questions.length || workspace.toolApprovals.length" class="pending-section">
+      <div
+        v-if="workspace.proposals.length || workspace.sleepRequests.length || workspace.questions.length || workspace.toolApprovals.length"
+        class="pending-section"
+      >
         <n-card
           v-for="p in workspace.proposals"
           :key="p.proposalId"
           class="pending-card"
           :title="`${p.proposedByAgentName} 提议创建新 Agent`"
         >
-          <n-form label-placement="left" label-width="80px" size="small">
+          <p class="pending-countdown">
+            {{ pendingCountdown(p.createdAt) }}
+          </p>
+          <n-form
+            label-placement="left"
+            label-width="80px"
+            size="small"
+          >
             <n-form-item label="名称">
-              <n-input v-model:value="proposalEdits[p.proposalId].name" placeholder="给这个 Agent 起个名字" />
+              <n-input
+                v-model:value="proposalEdits[p.proposalId].name"
+                placeholder="给这个 Agent 起个名字"
+              />
             </n-form-item>
             <n-form-item label="职责说明">
-              <n-input v-model:value="proposalEdits[p.proposalId].systemPrompt" type="textarea" :rows="2" placeholder="这个 Agent 的职责说明..." />
+              <n-input
+                v-model:value="proposalEdits[p.proposalId].systemPrompt"
+                type="textarea"
+                :rows="2"
+                placeholder="这个 Agent 的职责说明..."
+              />
             </n-form-item>
             <n-form-item label="提议的模型">
-              <n-text depth="3">{{ p.draft.provider }} / {{ p.draft.model }}（仅供参考，实际以下方选择的 API 配置为准）</n-text>
+              <n-text depth="3">
+                {{ p.draft.provider }} / {{ p.draft.model }}（仅供参考，实际以下方选择的 API 配置为准）
+              </n-text>
             </n-form-item>
-            <n-form-item label="API 配置" required>
-              <n-select v-model:value="proposalEdits[p.proposalId].apiConfigId" :options="settings.apiConfigOptions" placeholder="选择要使用的 API 配置" />
+            <n-form-item
+              label="API 配置"
+              required
+            >
+              <n-select
+                v-model:value="proposalEdits[p.proposalId].apiConfigId"
+                :options="settings.apiConfigOptions"
+                placeholder="选择要使用的 API 配置"
+              />
             </n-form-item>
-            <n-form-item label="MCP 工具" v-if="mcp.servers.length > 0">
+            <n-form-item
+              v-if="mcp.servers.length > 0"
+              label="MCP 工具"
+            >
               <n-checkbox-group v-model:value="proposalEdits[p.proposalId].mcpServerIds">
-                <n-space vertical size="small">
-                  <n-checkbox v-for="s in mcp.servers" :key="s.id" :value="s.id" :label="s.name" />
+                <n-space
+                  vertical
+                  size="small"
+                >
+                  <n-checkbox
+                    v-for="s in mcp.servers"
+                    :key="s.id"
+                    :value="s.id"
+                    :label="s.name"
+                  />
                 </n-space>
               </n-checkbox-group>
             </n-form-item>
-            <n-form-item label="知识库" v-if="kb.knowledgeBases.length > 0">
+            <n-form-item
+              v-if="kb.knowledgeBases.length > 0"
+              label="知识库"
+            >
               <n-checkbox-group v-model:value="proposalEdits[p.proposalId].knowledgeBaseIds">
-                <n-space vertical size="small">
-                  <n-checkbox v-for="item in kb.knowledgeBases" :key="item.id" :value="item.id" :label="item.name" />
+                <n-space
+                  vertical
+                  size="small"
+                >
+                  <n-checkbox
+                    v-for="item in kb.knowledgeBases"
+                    :key="item.id"
+                    :value="item.id"
+                    :label="item.name"
+                  />
                 </n-space>
               </n-checkbox-group>
             </n-form-item>
-            <n-form-item label="Skill" v-if="skills.skills.length > 0">
+            <n-form-item
+              v-if="skills.skills.length > 0"
+              label="Skill"
+            >
               <n-checkbox-group v-model:value="proposalEdits[p.proposalId].activeSkillIds">
-                <n-space vertical size="small">
-                  <n-checkbox v-for="sk in skills.skills" :key="sk.id" :value="sk.id" :label="sk.name" />
+                <n-space
+                  vertical
+                  size="small"
+                >
+                  <n-checkbox
+                    v-for="sk in skills.skills"
+                    :key="sk.id"
+                    :value="sk.id"
+                    :label="sk.name"
+                  />
                 </n-space>
               </n-checkbox-group>
             </n-form-item>
           </n-form>
           <n-space justify="end">
-            <n-button @click="handleRejectProposal(p)">拒绝</n-button>
-            <n-button type="primary" @click="handleApproveProposal(p)">批准并创建</n-button>
+            <n-button @click="handleRejectProposal(p)">
+              拒绝
+            </n-button>
+            <n-button
+              type="primary"
+              @click="handleApproveProposal(p)"
+            >
+              批准并创建
+            </n-button>
           </n-space>
         </n-card>
 
-        <n-card v-for="r in workspace.sleepRequests" :key="r.requestId" class="pending-card" :title="`${r.agentName} 申请休眠`">
+        <n-card
+          v-for="r in workspace.sleepRequests"
+          :key="r.requestId"
+          class="pending-card"
+          :title="`${r.agentName} 申请休眠`"
+        >
+          <p class="pending-countdown">
+            {{ pendingCountdown(r.createdAt) }}
+          </p>
           <p>原因：{{ r.reason || "未说明" }}</p>
           <n-space justify="end">
-            <n-button @click="handleResolveSleep(r.requestId, false)">拒绝</n-button>
-            <n-button type="primary" @click="handleResolveSleep(r.requestId, true)">批准休眠</n-button>
+            <n-button @click="handleResolveSleep(r.requestId, false)">
+              拒绝
+            </n-button>
+            <n-button
+              type="primary"
+              @click="handleResolveSleep(r.requestId, true)"
+            >
+              批准休眠
+            </n-button>
           </n-space>
         </n-card>
 
-        <n-card v-for="q in workspace.questions" :key="q.questionId" class="pending-card" :title="`${q.agentName} 的提问`">
+        <n-card
+          v-for="q in workspace.questions"
+          :key="q.questionId"
+          class="pending-card"
+          :title="`${q.agentName} 的提问`"
+        >
+          <p class="pending-countdown">
+            {{ pendingCountdown(q.createdAt) }}
+          </p>
           <p>{{ q.question }}</p>
-          <n-space>
-            <n-input v-model:value="answerDrafts[q.questionId]" placeholder="输入回答..." style="width: 260px" @keyup.enter="handleAnswer(q.questionId)" />
-            <n-button type="primary" @click="handleAnswer(q.questionId)">提交回答</n-button>
-          </n-space>
+          <div class="answer-row">
+            <n-input
+              v-model:value="answerDrafts[q.questionId]"
+              type="textarea"
+              :autosize="{ minRows: 1, maxRows: 4 }"
+              placeholder="输入回答，Enter 提交、Shift+Enter 换行..."
+              @keydown.enter="handleAnswerKeydown(q.questionId, $event)"
+            />
+            <n-button
+              type="primary"
+              @click="handleAnswer(q.questionId)"
+            >
+              提交回答
+            </n-button>
+          </div>
         </n-card>
 
-        <n-card v-for="t in workspace.toolApprovals" :key="t.approvalId" class="pending-card" :title="`${t.agentName} 请求执行工具「${t.toolName}」`">
+        <n-card
+          v-for="t in workspace.toolApprovals"
+          :key="t.approvalId"
+          class="pending-card"
+          :title="`${t.agentName} 请求执行工具「${t.toolName}」`"
+        >
+          <p class="pending-countdown">
+            {{ pendingCountdown(t.createdAt) }}（超时默认拒绝）
+          </p>
           <pre class="tool-args">{{ JSON.stringify(t.arguments, null, 2) }}</pre>
           <n-space justify="end">
-            <n-button @click="handleResolveToolApproval(t, false)">拒绝</n-button>
-            <n-button type="primary" @click="handleResolveToolApproval(t, true)">批准执行</n-button>
+            <n-button @click="handleResolveToolApproval(t, false)">
+              拒绝
+            </n-button>
+            <n-button
+              type="primary"
+              @click="handleResolveToolApproval(t, true)"
+            >
+              批准执行
+            </n-button>
           </n-space>
         </n-card>
       </div>
 
-      <n-grid :cols="3" :x-gap="16" class="main-grid">
+      <!-- 窄窗口/大字体时三栏挤不下，按容器宽度降级成两栏/单栏堆叠 -->
+      <n-grid
+        cols="1 860:2 1280:3"
+        responsive="self"
+        :x-gap="16"
+        :y-gap="16"
+        class="main-grid"
+      >
         <n-gi>
-          <n-card title="Agent 列表" class="panel-card" :bordered="false">
+          <n-card
+            title="Agent 列表"
+            class="panel-card"
+            :bordered="false"
+          >
             <template #header-extra>
               <n-space size="small">
-                <n-button size="small" quaternary @click="openSchedulerPage" :disabled="!workspace.currentWorkspace" title="管理定时任务">
-                  <template #icon><n-icon><AlarmOutline /></n-icon></template>
+                <n-button
+                  size="small"
+                  quaternary
+                  :disabled="!workspace.currentWorkspace"
+                  title="管理定时任务"
+                  @click="openSchedulerPage"
+                >
+                  <template #icon>
+                    <n-icon><AlarmOutline /></n-icon>
+                  </template>
                 </n-button>
-                <n-button size="small" quaternary @click="showBroadcastModal = true" :disabled="workspace.activeAgents.length === 0" title="广播给所有 Agent">
-                  <template #icon><n-icon><MegaphoneOutline /></n-icon></template>
+                <n-button
+                  size="small"
+                  quaternary
+                  :disabled="workspace.activeAgents.length === 0"
+                  title="广播给所有 Agent"
+                  @click="showBroadcastModal = true"
+                >
+                  <template #icon>
+                    <n-icon><MegaphoneOutline /></n-icon>
+                  </template>
                 </n-button>
-                <n-button size="small" type="primary" @click="openCreateAgentModal">
-                  <template #icon><n-icon><Add /></n-icon></template>
+                <n-button
+                  size="small"
+                  type="primary"
+                  @click="openCreateAgentModal"
+                >
+                  <template #icon>
+                    <n-icon><Add /></n-icon>
+                  </template>
                   添加 Agent
                 </n-button>
               </n-space>
             </template>
-            <n-list hoverable clickable class="agent-list">
+            <n-list
+              hoverable
+              clickable
+              class="agent-list"
+            >
               <n-list-item
                 v-for="agent in workspace.activeAgents"
                 :key="agent.id"
@@ -675,33 +1017,96 @@ onMounted(async () => {
                 <n-thing>
                   <template #header>
                     {{ agent.name }}
-                    <n-tag size="small" :type="agent.role === 'main' ? 'warning' : 'default'">{{ agent.role === "main" ? "主管" : "子Agent" }}</n-tag>
+                    <n-tag
+                      size="small"
+                      :type="agent.role === 'main' ? 'warning' : 'default'"
+                    >
+                      {{ agent.role === "main" ? "主管" : "子Agent" }}
+                    </n-tag>
                   </template>
-                  <template #description>{{ agent.provider }} / {{ agent.model }}</template>
+                  <template #description>
+                    {{ agent.provider }} / {{ agent.model }}
+                  </template>
                 </n-thing>
                 <template #suffix>
-                  <n-space vertical align="end" size="small">
-                    <n-tooltip v-if="agent.status === 'error'" trigger="hover">
+                  <n-space
+                    vertical
+                    align="end"
+                    size="small"
+                  >
+                    <n-tooltip
+                      v-if="agent.status === 'error'"
+                      trigger="hover"
+                    >
                       <template #trigger>
-                        <n-tag size="small" :type="statusMeta[agent.status].type">{{ statusMeta[agent.status].label }}</n-tag>
+                        <n-tag
+                          size="small"
+                          :type="statusMeta[agent.status].type"
+                        >
+                          {{ statusMeta[agent.status].label }}
+                        </n-tag>
                       </template>
                       {{ workspace.latestErrorFor(agent.id) ?? "未知错误，请查看活动时间线" }}
                     </n-tooltip>
-                    <n-tag v-else size="small" :type="statusMeta[agent.status].type">{{ statusMeta[agent.status].label }}</n-tag>
+                    <n-tag
+                      v-else
+                      size="small"
+                      :type="statusMeta[agent.status].type"
+                    >
+                      {{ statusMeta[agent.status].label }}
+                    </n-tag>
                     <n-space size="small">
-                      <n-button v-if="agent.status === 'paused'" quaternary circle size="tiny" @click.stop="handleResumeAgent(agent.id)" title="恢复运行">
-                        <template #icon><n-icon><PlayOutline /></n-icon></template>
+                      <n-button
+                        v-if="agent.status === 'paused'"
+                        quaternary
+                        circle
+                        size="tiny"
+                        title="恢复运行"
+                        @click.stop="handleResumeAgent(agent.id)"
+                      >
+                        <template #icon>
+                          <n-icon><PlayOutline /></n-icon>
+                        </template>
                       </n-button>
-                      <n-button v-else quaternary circle size="tiny" @click.stop="handlePauseAgent(agent.id)" title="暂停（紧急停止）">
-                        <template #icon><n-icon><PauseOutline /></n-icon></template>
+                      <n-button
+                        v-else
+                        quaternary
+                        circle
+                        size="tiny"
+                        title="暂停（紧急停止）"
+                        @click.stop="handlePauseAgent(agent.id)"
+                      >
+                        <template #icon>
+                          <n-icon><PauseOutline /></n-icon>
+                        </template>
                       </n-button>
-                      <n-button quaternary circle size="tiny" @click.stop="openEditAgentModal(agent)" title="编辑">
-                        <template #icon><n-icon><PencilOutline /></n-icon></template>
+                      <n-button
+                        quaternary
+                        circle
+                        size="tiny"
+                        title="编辑"
+                        @click.stop="openEditAgentModal(agent)"
+                      >
+                        <template #icon>
+                          <n-icon><PencilOutline /></n-icon>
+                        </template>
                       </n-button>
-                      <n-popconfirm positive-text="删除" negative-text="取消" @positive-click="handleDeleteAgent(agent.id)">
+                      <n-popconfirm
+                        positive-text="删除"
+                        negative-text="取消"
+                        @positive-click="handleDeleteAgent(agent.id)"
+                      >
                         <template #trigger>
-                          <n-button quaternary circle size="tiny" type="error" @click.stop>
-                            <template #icon><n-icon><TrashOutline /></n-icon></template>
+                          <n-button
+                            quaternary
+                            circle
+                            size="tiny"
+                            type="error"
+                            @click.stop
+                          >
+                            <template #icon>
+                              <n-icon><TrashOutline /></n-icon>
+                            </template>
                           </n-button>
                         </template>
                         确定删除 Agent「{{ agent.name }}」？
@@ -711,37 +1116,115 @@ onMounted(async () => {
                 </template>
               </n-list-item>
             </n-list>
-            <n-empty v-if="workspace.activeAgents.length === 0" description="还没有 Agent" size="small" />
+            <n-empty
+              v-if="workspace.activeAgents.length === 0"
+              description="还没有 Agent"
+              size="small"
+            />
           </n-card>
         </n-gi>
 
         <n-gi>
-          <n-card title="对话" class="panel-card" :bordered="false">
+          <n-card
+            title="对话"
+            class="panel-card"
+            :bordered="false"
+          >
             <template #header-extra>
-              <n-button v-if="selectedAgent" size="small" quaternary @click="loadAgentTasks" title="刷新任务清单">
-                <template #icon><n-icon><RefreshOutline /></n-icon></template>
-              </n-button>
+              <n-space
+                v-if="selectedAgent"
+                size="small"
+              >
+                <n-button
+                  size="small"
+                  quaternary
+                  title="查看/编辑工作备忘"
+                  @click="openScratchpadModal"
+                >
+                  <template #icon>
+                    <n-icon><DocumentTextOutline /></n-icon>
+                  </template>
+                </n-button>
+                <n-button
+                  size="small"
+                  quaternary
+                  title="刷新任务清单"
+                  @click="loadAgentTasks"
+                >
+                  <template #icon>
+                    <n-icon><RefreshOutline /></n-icon>
+                  </template>
+                </n-button>
+              </n-space>
             </template>
-            <n-empty v-if="!selectedAgent" description="选择一个 Agent 查看/发起对话" />
+            <n-empty
+              v-if="!selectedAgent"
+              description="选择一个 Agent 查看/发起对话"
+            />
             <template v-else>
-              <div v-if="agentTasks.length > 0" class="task-list">
-                <div v-for="t in agentTasks" :key="t.id" class="task-item">
-                  <n-checkbox :checked="t.done" @update:checked="(v: boolean) => handleToggleTask(t.id, v)" />
+              <div
+                v-if="agentTasks.length > 0"
+                class="task-list"
+              >
+                <div
+                  v-for="t in agentTasks"
+                  :key="t.id"
+                  class="task-item"
+                >
+                  <n-checkbox
+                    :checked="t.done"
+                    @update:checked="(v: boolean) => handleToggleTask(t.id, v)"
+                  />
                   <span :class="{ 'task-done': t.done }">{{ t.content }}</span>
                 </div>
               </div>
-              <div class="message-scroll">
-                <n-button v-if="workspace.hasMoreMessages" size="tiny" quaternary block @click="workspace.loadMoreMessages" class="load-more-btn">
+              <div
+                ref="messageScrollRef"
+                class="message-scroll"
+                @scroll="handleMessageScroll"
+              >
+                <n-button
+                  v-if="workspace.hasMoreMessages"
+                  size="tiny"
+                  quaternary
+                  block
+                  class="load-more-btn"
+                  @click="workspace.loadMoreMessages"
+                >
                   加载更早的消息
                 </n-button>
-                <ChatMessage v-for="m in agentMessages" :key="m.id" :message="m" />
-                <n-empty v-if="agentMessages.length === 0" description="还没有消息" size="small" />
-                <p v-if="selectedAgent.status === 'running'" class="running-indicator">「{{ selectedAgent.name }}」正在处理…</p>
+                <ChatMessage
+                  v-for="m in agentMessages"
+                  :key="m.id"
+                  :message="m"
+                />
+                <n-empty
+                  v-if="agentMessages.length === 0"
+                  description="还没有消息"
+                  size="small"
+                />
+                <p
+                  v-if="selectedAgent.status === 'running'"
+                  class="running-indicator"
+                >
+                  「{{ selectedAgent.name }}」正在处理…
+                </p>
               </div>
               <div class="message-input-row">
-                <n-input v-model:value="newMessageContent" placeholder="给这个 Agent 发消息..." @keyup.enter="handleSendMessage" />
-                <n-button type="primary" @click="handleSendMessage">
-                  <template #icon><n-icon><EnterOutline /></n-icon></template>
+                <n-input
+                  v-model:value="newMessageContent"
+                  type="textarea"
+                  :autosize="{ minRows: 1, maxRows: 5 }"
+                  placeholder="给这个 Agent 发消息，Enter 发送、Shift+Enter 换行..."
+                  @keydown.enter="handleMessageKeydown"
+                />
+                <n-button
+                  type="primary"
+                  @click="handleSendMessage"
+                >
+                  <template #icon>
+                    <n-icon><EnterOutline /></n-icon>
+                  </template>
                 </n-button>
               </div>
             </template>
@@ -749,9 +1232,32 @@ onMounted(async () => {
         </n-gi>
 
         <n-gi>
-          <n-card title="活动时间线" class="panel-card" :bordered="false">
-            <div class="timeline-scroll">
-              <n-button v-if="workspace.hasMoreLogs" size="tiny" quaternary block @click="workspace.loadMoreLogs" class="load-more-btn">
+          <n-card
+            title="活动时间线"
+            class="panel-card"
+            :bordered="false"
+          >
+            <template #header-extra>
+              <n-select
+                v-model:value="timelineFilter"
+                :options="timelineFilterOptions"
+                size="small"
+                style="width: 110px"
+              />
+            </template>
+            <div
+              ref="timelineScrollRef"
+              class="timeline-scroll"
+              @scroll="handleTimelineScroll"
+            >
+              <n-button
+                v-if="workspace.hasMoreLogs"
+                size="tiny"
+                quaternary
+                block
+                class="load-more-btn"
+                @click="workspace.loadMoreLogs"
+              >
                 加载更早的记录
               </n-button>
               <n-timeline>
@@ -764,7 +1270,11 @@ onMounted(async () => {
                   :time="formatTime(entry.createdAt)"
                 />
               </n-timeline>
-              <n-empty v-if="timeline.length === 0" description="还没有活动记录" size="small" />
+              <n-empty
+                v-if="timeline.length === 0"
+                description="还没有活动记录"
+                size="small"
+              />
             </div>
           </n-card>
         </n-gi>
@@ -772,179 +1282,484 @@ onMounted(async () => {
     </template>
 
     <!-- 新建工作组 -->
-    <n-modal v-model:show="showCreateWorkspaceModal" preset="card" title="新建工作组" style="width: 480px">
-      <n-form label-placement="left" label-width="110px">
-        <n-form-item label="名称" required>
-          <n-input v-model:value="wsForm.name" placeholder="例如：产品文案小组" />
+    <n-modal
+      v-model:show="showCreateWorkspaceModal"
+      preset="card"
+      title="新建工作组"
+      style="width: 480px"
+    >
+      <n-form
+        label-placement="left"
+        label-width="110px"
+      >
+        <n-form-item
+          label="名称"
+          required
+        >
+          <n-input
+            v-model:value="wsForm.name"
+            placeholder="例如：产品文案小组"
+          />
         </n-form-item>
         <n-form-item label="描述">
-          <n-input v-model:value="wsForm.description" type="textarea" :rows="2" placeholder="简要描述这个工作组的用途（可选）" />
+          <n-input
+            v-model:value="wsForm.description"
+            type="textarea"
+            :rows="2"
+            placeholder="简要描述这个工作组的用途（可选）"
+          />
         </n-form-item>
         <n-form-item label="Agent 数量上限">
-          <n-input-number v-model:value="wsForm.maxAgents" :min="1" :max="20" />
+          <n-input-number
+            v-model:value="wsForm.maxAgents"
+            :min="1"
+            :max="20"
+          />
         </n-form-item>
       </n-form>
       <template #footer>
         <n-space justify="end">
-          <n-button @click="showCreateWorkspaceModal = false">取消</n-button>
-          <n-button type="primary" @click="handleCreateWorkspace">创建</n-button>
+          <n-button @click="showCreateWorkspaceModal = false">
+            取消
+          </n-button>
+          <n-button
+            type="primary"
+            @click="handleCreateWorkspace"
+          >
+            创建
+          </n-button>
         </n-space>
       </template>
     </n-modal>
 
     <!-- 添加 Agent -->
-    <n-modal v-model:show="showCreateAgentModal" preset="card" title="添加 Agent" style="width: 600px; max-height: 85vh" :content-style="{ overflowY: 'auto' }">
-      <n-form label-placement="left" label-width="100px">
-        <n-form-item label="名称" required>
-          <n-input v-model:value="agentForm.name" placeholder="给这个 Agent 起个名字" />
+    <n-modal
+      v-model:show="showCreateAgentModal"
+      preset="card"
+      title="添加 Agent"
+      style="width: 600px; max-height: 85vh"
+      :content-style="{ overflowY: 'auto' }"
+    >
+      <n-form
+        label-placement="left"
+        label-width="100px"
+      >
+        <n-form-item
+          label="名称"
+          required
+        >
+          <n-input
+            v-model:value="agentForm.name"
+            placeholder="给这个 Agent 起个名字"
+          />
         </n-form-item>
         <n-form-item label="角色">
           <n-radio-group v-model:value="agentForm.role">
-            <n-radio value="main">主管 Agent</n-radio>
-            <n-radio value="sub">子 Agent</n-radio>
+            <n-radio value="main">
+              主管 Agent
+            </n-radio>
+            <n-radio value="sub">
+              子 Agent
+            </n-radio>
           </n-radio-group>
         </n-form-item>
-        <n-form-item label="API 配置" required>
-          <n-select v-model:value="agentForm.apiConfigId" :options="settings.apiConfigOptions" placeholder="选择已保存的 API 配置" />
+        <n-form-item
+          label="API 配置"
+          required
+        >
+          <n-select
+            v-model:value="agentForm.apiConfigId"
+            :options="settings.apiConfigOptions"
+            placeholder="选择已保存的 API 配置"
+          />
         </n-form-item>
         <n-form-item label="系统提示词">
-          <n-input v-model:value="agentForm.systemPrompt" type="textarea" :rows="4" placeholder="这个 Agent 的职责说明..." />
+          <n-input
+            v-model:value="agentForm.systemPrompt"
+            type="textarea"
+            :rows="4"
+            placeholder="这个 Agent 的职责说明..."
+          />
         </n-form-item>
         <n-form-item label="思考模式">
           <n-space align="center">
             <n-switch v-model:value="agentForm.enableThinking" />
-            <n-text depth="3" style="font-size: 12px">开启后模型会先深度思考再回复，更费时间和 token，复杂任务再开</n-text>
+            <n-text
+              depth="3"
+              style="font-size: 12px"
+            >
+              开启后模型会先深度思考再回复，更费时间和 token，复杂任务再开
+            </n-text>
           </n-space>
         </n-form-item>
-        <n-form-item label="MCP 工具" v-if="mcp.servers.length > 0">
+        <n-form-item
+          v-if="mcp.servers.length > 0"
+          label="MCP 工具"
+        >
           <n-checkbox-group v-model:value="agentForm.mcpServerIds">
-            <n-space vertical size="small">
-              <n-checkbox v-for="s in mcp.servers" :key="s.id" :value="s.id" :label="s.name" />
+            <n-space
+              vertical
+              size="small"
+            >
+              <n-checkbox
+                v-for="s in mcp.servers"
+                :key="s.id"
+                :value="s.id"
+                :label="s.name"
+              />
             </n-space>
           </n-checkbox-group>
         </n-form-item>
-        <n-form-item v-if="mcp.servers.length > 0" label="高风险工具需批准">
+        <n-form-item
+          v-if="mcp.servers.length > 0"
+          label="高风险工具需批准"
+        >
           <n-space align="center">
             <n-switch v-model:value="agentForm.requireToolApproval" />
-            <n-text depth="3" style="font-size: 12px">开启后（默认），删除/写入/执行命令等高风险工具调用前需要你批准，其余工具照常自动放行；关闭则全部自动放行，风险自担</n-text>
+            <n-text
+              depth="3"
+              style="font-size: 12px"
+            >
+              开启后（默认），删除/写入/执行命令等高风险工具调用前需要你批准，其余工具照常自动放行；关闭则全部自动放行，风险自担
+            </n-text>
           </n-space>
         </n-form-item>
-        <n-form-item label="知识库" v-if="kb.knowledgeBases.length > 0">
+        <n-form-item
+          v-if="kb.knowledgeBases.length > 0"
+          label="知识库"
+        >
           <n-checkbox-group v-model:value="agentForm.knowledgeBaseIds">
-            <n-space vertical size="small">
-              <n-checkbox v-for="item in kb.knowledgeBases" :key="item.id" :value="item.id" :label="item.name" />
+            <n-space
+              vertical
+              size="small"
+            >
+              <n-checkbox
+                v-for="item in kb.knowledgeBases"
+                :key="item.id"
+                :value="item.id"
+                :label="item.name"
+              />
             </n-space>
           </n-checkbox-group>
         </n-form-item>
         <template v-if="agentForm.knowledgeBaseIds.length > 0">
           <n-form-item label="检索 top_k">
-            <n-input-number v-model:value="agentForm.ragTopK" :min="1" :max="20" />
+            <n-input-number
+              v-model:value="agentForm.ragTopK"
+              :min="1"
+              :max="20"
+            />
           </n-form-item>
           <n-form-item label="检索模式">
-            <n-select v-model:value="agentForm.ragRetrievalMode" :options="retrievalModeOptions" />
+            <n-select
+              v-model:value="agentForm.ragRetrievalMode"
+              :options="retrievalModeOptions"
+            />
           </n-form-item>
-          <n-form-item label="Reranker" v-if="settings.rerankerApiConfigOptions.length > 0">
-            <n-select v-model:value="agentForm.ragRerankerConfigId" :options="settings.rerankerApiConfigOptions" clearable placeholder="不启用精排（可选）" />
+          <n-form-item
+            v-if="settings.rerankerApiConfigOptions.length > 0"
+            label="Reranker"
+          >
+            <n-select
+              v-model:value="agentForm.ragRerankerConfigId"
+              :options="settings.rerankerApiConfigOptions"
+              clearable
+              placeholder="不启用精排（可选）"
+            />
           </n-form-item>
-          <n-form-item label="精排保留条数" v-if="agentForm.ragRerankerConfigId">
-            <n-input-number v-model:value="agentForm.ragRerankTopN" :min="1" :max="agentForm.ragTopK" placeholder="默认等于 top_k" />
+          <n-form-item
+            v-if="agentForm.ragRerankerConfigId"
+            label="精排保留条数"
+          >
+            <n-input-number
+              v-model:value="agentForm.ragRerankTopN"
+              :min="1"
+              :max="agentForm.ragTopK"
+              placeholder="默认等于 top_k"
+            />
           </n-form-item>
         </template>
-        <n-form-item label="Skill" v-if="skills.skills.length > 0">
+        <n-form-item
+          v-if="skills.skills.length > 0"
+          label="Skill"
+        >
           <n-checkbox-group v-model:value="agentForm.activeSkillIds">
-            <n-space vertical size="small">
-              <n-checkbox v-for="sk in skills.skills" :key="sk.id" :value="sk.id" :label="sk.name" />
+            <n-space
+              vertical
+              size="small"
+            >
+              <n-checkbox
+                v-for="sk in skills.skills"
+                :key="sk.id"
+                :value="sk.id"
+                :label="sk.name"
+              />
             </n-space>
           </n-checkbox-group>
         </n-form-item>
       </n-form>
       <template #footer>
         <n-space justify="end">
-          <n-button @click="showCreateAgentModal = false">取消</n-button>
-          <n-button type="primary" @click="handleCreateAgent">添加</n-button>
+          <n-button @click="showCreateAgentModal = false">
+            取消
+          </n-button>
+          <n-button
+            type="primary"
+            @click="handleCreateAgent"
+          >
+            添加
+          </n-button>
         </n-space>
       </template>
     </n-modal>
 
     <!-- 编辑 Agent -->
-    <n-modal v-model:show="showEditAgentModal" preset="card" title="编辑 Agent" style="width: 600px; max-height: 85vh" :content-style="{ overflowY: 'auto' }">
-      <n-form v-if="editAgentForm" label-placement="left" label-width="100px">
-        <n-form-item label="名称" required>
-          <n-input v-model:value="editAgentForm.name" placeholder="给这个 Agent 起个名字" />
+    <n-modal
+      v-model:show="showEditAgentModal"
+      preset="card"
+      title="编辑 Agent"
+      style="width: 600px; max-height: 85vh"
+      :content-style="{ overflowY: 'auto' }"
+    >
+      <n-form
+        v-if="editAgentForm"
+        label-placement="left"
+        label-width="100px"
+      >
+        <n-form-item
+          label="名称"
+          required
+        >
+          <n-input
+            v-model:value="editAgentForm.name"
+            placeholder="给这个 Agent 起个名字"
+          />
         </n-form-item>
-        <n-form-item label="API 配置" required>
-          <n-select v-model:value="editAgentForm.apiConfigId" :options="settings.apiConfigOptions" placeholder="选择已保存的 API 配置" />
+        <n-form-item
+          label="API 配置"
+          required
+        >
+          <n-select
+            v-model:value="editAgentForm.apiConfigId"
+            :options="settings.apiConfigOptions"
+            placeholder="选择已保存的 API 配置"
+          />
         </n-form-item>
         <n-form-item label="系统提示词">
-          <n-input v-model:value="editAgentForm.systemPrompt" type="textarea" :rows="4" placeholder="这个 Agent 的职责说明..." />
+          <n-input
+            v-model:value="editAgentForm.systemPrompt"
+            type="textarea"
+            :rows="4"
+            placeholder="这个 Agent 的职责说明..."
+          />
         </n-form-item>
         <n-form-item label="思考模式">
           <n-space align="center">
             <n-switch v-model:value="editAgentForm.enableThinking" />
-            <n-text depth="3" style="font-size: 12px">开启后模型会先深度思考再回复，更费时间和 token，复杂任务再开</n-text>
+            <n-text
+              depth="3"
+              style="font-size: 12px"
+            >
+              开启后模型会先深度思考再回复，更费时间和 token，复杂任务再开
+            </n-text>
           </n-space>
         </n-form-item>
-        <n-form-item label="MCP 工具" v-if="mcp.servers.length > 0">
+        <n-form-item
+          v-if="mcp.servers.length > 0"
+          label="MCP 工具"
+        >
           <n-checkbox-group v-model:value="editAgentForm.mcpServerIds">
-            <n-space vertical size="small">
-              <n-checkbox v-for="s in mcp.servers" :key="s.id" :value="s.id" :label="s.name" />
+            <n-space
+              vertical
+              size="small"
+            >
+              <n-checkbox
+                v-for="s in mcp.servers"
+                :key="s.id"
+                :value="s.id"
+                :label="s.name"
+              />
             </n-space>
           </n-checkbox-group>
         </n-form-item>
-        <n-form-item v-if="mcp.servers.length > 0" label="高风险工具需批准">
+        <n-form-item
+          v-if="mcp.servers.length > 0"
+          label="高风险工具需批准"
+        >
           <n-space align="center">
             <n-switch v-model:value="editAgentForm.requireToolApproval" />
-            <n-text depth="3" style="font-size: 12px">开启后（默认），删除/写入/执行命令等高风险工具调用前需要你批准，其余工具照常自动放行；关闭则全部自动放行，风险自担</n-text>
+            <n-text
+              depth="3"
+              style="font-size: 12px"
+            >
+              开启后（默认），删除/写入/执行命令等高风险工具调用前需要你批准，其余工具照常自动放行；关闭则全部自动放行，风险自担
+            </n-text>
           </n-space>
         </n-form-item>
-        <n-form-item label="知识库" v-if="kb.knowledgeBases.length > 0">
+        <n-form-item
+          v-if="kb.knowledgeBases.length > 0"
+          label="知识库"
+        >
           <n-checkbox-group v-model:value="editAgentForm.knowledgeBaseIds">
-            <n-space vertical size="small">
-              <n-checkbox v-for="item in kb.knowledgeBases" :key="item.id" :value="item.id" :label="item.name" />
+            <n-space
+              vertical
+              size="small"
+            >
+              <n-checkbox
+                v-for="item in kb.knowledgeBases"
+                :key="item.id"
+                :value="item.id"
+                :label="item.name"
+              />
             </n-space>
           </n-checkbox-group>
         </n-form-item>
         <template v-if="editAgentForm.knowledgeBaseIds.length > 0">
           <n-form-item label="检索 top_k">
-            <n-input-number v-model:value="editAgentForm.ragTopK" :min="1" :max="20" />
+            <n-input-number
+              v-model:value="editAgentForm.ragTopK"
+              :min="1"
+              :max="20"
+            />
           </n-form-item>
           <n-form-item label="检索模式">
-            <n-select v-model:value="editAgentForm.ragRetrievalMode" :options="retrievalModeOptions" />
+            <n-select
+              v-model:value="editAgentForm.ragRetrievalMode"
+              :options="retrievalModeOptions"
+            />
           </n-form-item>
-          <n-form-item label="Reranker" v-if="settings.rerankerApiConfigOptions.length > 0">
-            <n-select v-model:value="editAgentForm.ragRerankerConfigId" :options="settings.rerankerApiConfigOptions" clearable placeholder="不启用精排（可选）" />
+          <n-form-item
+            v-if="settings.rerankerApiConfigOptions.length > 0"
+            label="Reranker"
+          >
+            <n-select
+              v-model:value="editAgentForm.ragRerankerConfigId"
+              :options="settings.rerankerApiConfigOptions"
+              clearable
+              placeholder="不启用精排（可选）"
+            />
           </n-form-item>
-          <n-form-item label="精排保留条数" v-if="editAgentForm.ragRerankerConfigId">
-            <n-input-number v-model:value="editAgentForm.ragRerankTopN" :min="1" :max="editAgentForm.ragTopK" placeholder="默认等于 top_k" />
+          <n-form-item
+            v-if="editAgentForm.ragRerankerConfigId"
+            label="精排保留条数"
+          >
+            <n-input-number
+              v-model:value="editAgentForm.ragRerankTopN"
+              :min="1"
+              :max="editAgentForm.ragTopK"
+              placeholder="默认等于 top_k"
+            />
           </n-form-item>
         </template>
-        <n-form-item label="Skill" v-if="skills.skills.length > 0">
+        <n-form-item
+          v-if="skills.skills.length > 0"
+          label="Skill"
+        >
           <n-checkbox-group v-model:value="editAgentForm.activeSkillIds">
-            <n-space vertical size="small">
-              <n-checkbox v-for="sk in skills.skills" :key="sk.id" :value="sk.id" :label="sk.name" />
+            <n-space
+              vertical
+              size="small"
+            >
+              <n-checkbox
+                v-for="sk in skills.skills"
+                :key="sk.id"
+                :value="sk.id"
+                :label="sk.name"
+              />
             </n-space>
           </n-checkbox-group>
         </n-form-item>
       </n-form>
       <template #footer>
         <n-space justify="end">
-          <n-button @click="showEditAgentModal = false">取消</n-button>
-          <n-button type="primary" @click="handleUpdateAgent">保存</n-button>
+          <n-button @click="showEditAgentModal = false">
+            取消
+          </n-button>
+          <n-button
+            type="primary"
+            @click="handleUpdateAgent"
+          >
+            保存
+          </n-button>
         </n-space>
       </template>
     </n-modal>
 
     <!-- 广播消息 -->
-    <n-modal v-model:show="showBroadcastModal" preset="card" title="广播给所有 Agent" style="width: 480px">
-      <n-input v-model:value="broadcastContent" type="textarea" :rows="3" placeholder="这条消息会发给工作组里的每一个 Agent..." />
+    <n-modal
+      v-model:show="showBroadcastModal"
+      preset="card"
+      title="广播给所有 Agent"
+      style="width: 480px"
+    >
+      <n-input
+        v-model:value="broadcastContent"
+        type="textarea"
+        :rows="3"
+        placeholder="这条消息会发给工作组里的每一个 Agent..."
+      />
       <template #footer>
         <n-space justify="end">
-          <n-button @click="showBroadcastModal = false">取消</n-button>
-          <n-button type="primary" @click="handleBroadcastSend">发送</n-button>
+          <n-button @click="showBroadcastModal = false">
+            取消
+          </n-button>
+          <n-button
+            type="primary"
+            @click="handleBroadcastSend"
+          >
+            发送
+          </n-button>
         </n-space>
       </template>
     </n-modal>
 
+    <!-- Agent 工作备忘（scratchpad）：Agent 跨唤醒的私人记忆，用户可查看/修改/清空 -->
+    <n-modal
+      v-model:show="showScratchpadModal"
+      preset="card"
+      :title="`「${selectedAgent?.name ?? ''}」的工作备忘`"
+      style="width: 560px"
+    >
+      <n-text
+        depth="3"
+        style="font-size: 12px; display: block; margin-bottom: 8px"
+      >
+        这是这个 Agent 自己维护的跨唤醒记忆（每次唤醒都会拼进它的系统提示词）。它记了什么、有没有记偏，你可以在这里直接查看和修正。
+      </n-text>
+      <n-input
+        v-model:value="scratchpadDraft"
+        type="textarea"
+        :autosize="{ minRows: 6, maxRows: 16 }"
+        placeholder="备忘为空。可以直接替 Agent 写一些它该记住的背景信息..."
+      />
+      <template #footer>
+        <n-space justify="space-between">
+          <n-popconfirm
+            positive-text="清空"
+            negative-text="取消"
+            @positive-click="handleClearScratchpad"
+          >
+            <template #trigger>
+              <n-button quaternary>
+                清空备忘
+              </n-button>
+            </template>
+            确定清空「{{ selectedAgent?.name }}」的工作备忘？它下次唤醒时将不再记得这些内容。
+          </n-popconfirm>
+          <n-space>
+            <n-button @click="showScratchpadModal = false">
+              关闭
+            </n-button>
+            <n-button
+              type="primary"
+              @click="handleSaveScratchpad"
+            >
+              保存
+            </n-button>
+          </n-space>
+        </n-space>
+      </template>
+    </n-modal>
   </div>
 </template>
 
@@ -989,6 +1804,25 @@ onMounted(async () => {
 
 .pending-card {
   border-left: 2px solid $ink;
+}
+
+// 待处理卡片的超时倒计时：小号浅色文字，别抢卡片正文的注意力。
+.pending-countdown {
+  margin: 0 0 8px;
+  font-size: $label-size;
+  letter-spacing: 0.05em;
+  color: $ink-faint;
+}
+
+// 提问卡片的回答行：多行输入占满剩余宽度，按钮贴底对齐。
+.answer-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+
+  .n-input {
+    flex: 1;
+  }
 }
 
 .main-grid {
@@ -1081,6 +1915,11 @@ onMounted(async () => {
 .message-input-row {
   display: flex;
   gap: 8px;
+  align-items: flex-end;
+
+  .n-input {
+    flex: 1;
+  }
 }
 
 .timeline-scroll {


### PR DESCRIPTION
基于 0.2.0-beta.10 复审报告逐项修复 21 项问题，版本升至 0.2.0-beta.11。

**P0**：手动暂停不再被唤醒收尾/出错路径覆盖（紧急停止真正可靠）；重启遗留的僵尸待处理卡片启动时统一过期清理 + resolve 自愈。

**P1**：新增 `workspace://pending-resolved` 事件实时撤卡；会议协议改点名发言制，API 调用从 O(S×N) 降到 O(S+N)；散会还原休眠状态；IME Enter 误发送修复 + 多行输入；`workspace_asks` 回答落库。

**P2**：广播按工作组收窄且虚假唤醒不再洗掉 Sleeping；验收计入 Error 终态 + 出错上报主 Agent；启动补处理积压消息；消息/时间线自动滚动。

**P3**：时间线过滤器/参数截断/跨天日期；scratchpad 可见可编辑；工作组选择持久化；监听移全局 + 侧边栏徽标 + 左下角提醒；卡片超时倒计时；危险词整词匹配；任务清单自动刷新；响应式栅格；过时注释清理；彩色核对结论为主题已全局黑白化、无需改动。

**验证**：pnpm build（vue-tsc）✅；cargo test 42/42 ✅；pnpm tauri build release 编译+NSIS 打包 ✅（仅 updater 签名因本机无私钥跳过，与代码无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)