### PR TITLE
fix: Chat 模块清理与四处运行时缺陷修复（思考模型空回复/工具调用被吞/missing apiKey/外链带走窗口）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.15",
+  "version": "0.2.0-beta.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.15"
+version = "0.2.0-beta.16"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -107,7 +107,13 @@ pub struct SendMessageRequest {
     pub provider: String,
     /// 模型名称
     pub model: String,
-    /// API 密钥
+    /// API 密钥。必须有 default：settings 持久化时会把 apiKey 字段剥掉（密钥
+    /// 只进系统 keyring），重启后本地 provider 的配置在 keyring 里没有条目可
+    /// 回填，前端会发出不带 apiKey 的请求——没有 default 时 serde 直接以
+    /// "missing field `apiKey`" 拒收整个请求，本地模型重启后就全用不了。
+    /// 空串对本地 provider 本来就是合法值（不鉴权），对其他 provider 则会
+    /// 走 get_api_key 的 keyring 兜底查找。
+    #[serde(default)]
     pub api_key: String,
     /// API 基础 URL
     pub base_url: String,
@@ -162,6 +168,10 @@ pub struct StreamChunk {
     pub message_id: String,
     /// 增量内容
     pub content: String,
+    /// 是否为思考过程增量。思考型模型（DeepSeek R1 系、Ollama 上的 qwen3.5
+    /// 等）会把思考内容放在 reasoning_content/reasoning 字段流式返回，前端
+    /// 据此把这部分归到"思考过程"折叠区，而不是混进正文。
+    pub is_thinking: bool,
     /// 是否完成
     pub done: bool,
 }
@@ -876,6 +886,14 @@ fn parse_sse_line(provider: &str, line: &str) -> Option<StreamContent> {
                             .get("text")
                             .and_then(|t| t.as_str())
                             .map(|s| StreamContent::Text(s.to_string())),
+                        // Extended Thinking 的思考增量。此前被静默丢弃——对
+                        // Anthropic 影响不大（思考后总会有 text_delta 正文），
+                        // 但既然前端有了思考过程展示区，一并转发保持一致。
+                        Some("thinking_delta") => delta
+                            .get("thinking")
+                            .and_then(|t| t.as_str())
+                            .filter(|s| !s.is_empty())
+                            .map(|s| StreamContent::Thinking(s.to_string())),
                         Some("input_json_delta") => {
                             let fragment = delta
                                 .get("partial_json")
@@ -916,9 +934,14 @@ fn parse_sse_line(provider: &str, line: &str) -> Option<StreamContent> {
             // OpenAI 格式
             if let Some(choices) = json["choices"].as_array() {
                 if let Some(first_choice) = choices.first() {
-                    if let Some(content) = first_choice["delta"]["content"].as_str() {
-                        return Some(StreamContent::Text(content.to_string()));
-                    } else if let Some(tool_calls) = first_choice["delta"]["tool_calls"].as_array() {
+                    let delta = &first_choice["delta"];
+
+                    // 必须先看 tool_calls、再看 content：Ollama 等实现会在携带
+                    // tool_calls 的 chunk 里同时带上 `"content": ""`（OpenAI 官方
+                    // 是 null）。如果先按 content 分支处理，空字符串照样命中
+                    // as_str()，同一个 chunk 里的 tool_calls 就被整个吞掉——
+                    // 表现为模型明明发起了工具调用，前端却毫无反应、收到空回复。
+                    if let Some(tool_calls) = delta["tool_calls"].as_array() {
                         // OpenAI 是增量流式发送工具调用的：某个 `index` 的第一个
                         // delta 携带 `id` + `function.name`，之后同一个 `index`
                         // 的后续每个 delta 只携带 `function.arguments` 的一个片段
@@ -940,6 +963,26 @@ fn parse_sse_line(provider: &str, line: &str) -> Option<StreamContent> {
                             return Some(StreamContent::ToolCallDeltas(deltas));
                         }
                     }
+
+                    if let Some(content) = delta["content"].as_str() {
+                        if !content.is_empty() {
+                            return Some(StreamContent::Text(content.to_string()));
+                        }
+                    }
+
+                    // 思考型模型的思考增量：DeepSeek/SiliconFlow 系用
+                    // reasoning_content，Ollama 用 reasoning。这类 chunk 的
+                    // content 恒为空串/null——丢弃它们的话，思考占比高的模型
+                    // （比如 Ollama 上的 qwen3.5）在用户看来就是等了半分钟
+                    // 收到一条空回复。单独作为思考过程转发，不混入正文。
+                    if let Some(reasoning) = delta["reasoning_content"]
+                        .as_str()
+                        .or_else(|| delta["reasoning"].as_str())
+                    {
+                        if !reasoning.is_empty() {
+                            return Some(StreamContent::Thinking(reasoning.to_string()));
+                        }
+                    }
                 }
             }
             None
@@ -950,6 +993,8 @@ fn parse_sse_line(provider: &str, line: &str) -> Option<StreamContent> {
 #[derive(Debug)]
 enum StreamContent {
     Text(String),
+    /// 思考型模型的思考过程增量（reasoning/reasoning_content/thinking_delta）
+    Thinking(String),
     ToolCallDeltas(Vec<ToolCallDelta>),
     Done,
 }
@@ -1159,6 +1204,7 @@ pub async fn stream_message(
                     session_id: request.session_id.clone(),
                     message_id: message_id.clone(),
                     content: String::new(),
+                    is_thinking: false,
                     done: true,
                 });
                 return Ok(());
@@ -1186,6 +1232,16 @@ pub async fn stream_message(
                                             session_id: request.session_id.clone(),
                                             message_id: message_id.clone(),
                                             content: text,
+                                            is_thinking: false,
+                                            done: false,
+                                        });
+                                    }
+                                    StreamContent::Thinking(text) => {
+                                        let _ = app_handle.emit("stream-chunk", StreamChunk {
+                                            session_id: request.session_id.clone(),
+                                            message_id: message_id.clone(),
+                                            content: text,
+                                            is_thinking: true,
                                             done: false,
                                         });
                                     }
@@ -1380,11 +1436,21 @@ async fn finalize_turn(
             )
             .await
             {
-                Ok(ContinuationResult::Text(live_reply)) => {
+                Ok(ContinuationResult::Text { text, thinking }) => {
+                    if let Some(th) = thinking.filter(|t| !t.is_empty()) {
+                        let _ = app_handle.emit("stream-chunk", StreamChunk {
+                            session_id: request.session_id.clone(),
+                            message_id: message_id.to_string(),
+                            content: th,
+                            is_thinking: true,
+                            done: false,
+                        });
+                    }
                     let _ = app_handle.emit("stream-chunk", StreamChunk {
                         session_id: request.session_id.clone(),
                         message_id: message_id.to_string(),
-                        content: live_reply,
+                        content: text,
+                        is_thinking: false,
                         done: false,
                     });
                     break;
@@ -1410,16 +1476,18 @@ async fn finalize_turn(
         session_id: request.session_id.clone(),
         message_id: message_id.to_string(),
         content: String::new(),
+        is_thinking: false,
         done: true,
     });
     Ok(())
 }
 
-/// 一次工具调用续写请求可能得到的两种结果：模型已经完成，给出了纯文本回复；
-/// 或者它还想继续调用工具（比如"列出允许访问的目录"接着"列出该目录下的
-/// 文件"——一轮里的两次调用）。`finalize_turn` 会对后一种情况循环处理。
+/// 一次工具调用续写请求可能得到的两种结果：模型已经完成，给出了文本回复
+/// （思考型模型可能附带甚至只有思考内容——qwen3.5 经 Ollama 续写时会把回答
+/// 埋进 reasoning、content 留空，这时思考内容是仅有的可展示产出）；或者它
+/// 还想继续调用工具。`finalize_turn` 会对后一种情况循环处理。
 enum ContinuationResult {
-    Text(String),
+    Text { text: String, thinking: Option<String> },
     ToolCalls(Vec<ToolCall>),
 }
 
@@ -1710,11 +1778,16 @@ async fn continue_after_tool_calls(
             if !tool_use_calls.is_empty() {
                 return Ok(ContinuationResult::ToolCalls(tool_use_calls));
             }
+            let thinking = blocks
+                .and_then(|arr| arr.iter().find(|b| b.get("type").and_then(|t| t.as_str()) == Some("thinking")))
+                .and_then(|b| b.get("thinking"))
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string());
             blocks
                 .and_then(|arr| arr.iter().find(|b| b.get("type").and_then(|t| t.as_str()) == Some("text")))
                 .and_then(|b| b.get("text"))
                 .and_then(|t| t.as_str())
-                .map(|s| ContinuationResult::Text(s.to_string()))
+                .map(|s| ContinuationResult::Text { text: s.to_string(), thinking })
                 .ok_or_else(|| LLMError::ApiError("LLM did not return content".to_string()))
         }
         "google" => {
@@ -1746,7 +1819,7 @@ async fn continue_after_tool_calls(
                 .and_then(|arr| arr.first())
                 .and_then(|part| part.get("text"))
                 .and_then(|t| t.as_str())
-                .map(|s| ContinuationResult::Text(s.to_string()))
+                .map(|s| ContinuationResult::Text { text: s.to_string(), thinking: None })
                 .ok_or_else(|| LLMError::ApiError("LLM did not return content".to_string()))
         }
         _ => {
@@ -1766,11 +1839,24 @@ async fn continue_after_tool_calls(
                             return Ok(ContinuationResult::ToolCalls(calls));
                         }
                     }
-                    if let Some(text) = first_choice["message"]["content"].as_str() {
-                        return Ok(ContinuationResult::Text(text.to_string()));
+                    // 思考型模型的非流式响应同样把思考放在 reasoning_content
+                    // （DeepSeek 系）/ reasoning（Ollama）字段；qwen3.5 经
+                    // Ollama 续写时甚至会 content 留空、只给 reasoning——这时
+                    // 思考内容是仅有的可展示产出，不能连同空 content 一起丢弃。
+                    let thinking = first_choice["message"]["reasoning_content"]
+                        .as_str()
+                        .or_else(|| first_choice["message"]["reasoning"].as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string());
+                    let content_text = first_choice["message"]["content"].as_str().unwrap_or("");
+                    if !content_text.is_empty() || thinking.is_some() {
+                        return Ok(ContinuationResult::Text {
+                            text: content_text.to_string(),
+                            thinking,
+                        });
                     }
                     if let Some(text) = first_choice["text"].as_str() {
-                        return Ok(ContinuationResult::Text(text.to_string()));
+                        return Ok(ContinuationResult::Text { text: text.to_string(), thinking: None });
                     }
                 }
             }
@@ -2388,6 +2474,58 @@ mod provider_tool_calling_tests {
         assert_eq!(tools[0]["function"]["name"], "get_weather");
     }
 
+    #[test]
+    fn openai_tool_calls_not_swallowed_by_empty_content_field() {
+        // Ollama 在携带 tool_calls 的 chunk 里同时带 `"content": ""`（OpenAI
+        // 官方是 null）。曾经的解析顺序先命中 content 分支，空串直接 return，
+        // 同一 chunk 的 tool_calls 被整个吞掉。
+        let parsed = parse_sse_line(
+            "local",
+            r#"data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"","tool_calls":[{"id":"call_1","index":0,"type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"SF\"}"}}]},"finish_reason":null}]}"#,
+        ).expect("tool_calls must be parsed even when content is an empty string");
+        match parsed {
+            StreamContent::ToolCallDeltas(deltas) => {
+                assert_eq!(deltas.len(), 1);
+                assert_eq!(deltas[0].id.as_deref(), Some("call_1"));
+                assert_eq!(deltas[0].name.as_deref(), Some("get_weather"));
+            }
+            other => panic!("expected ToolCallDeltas, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn openai_reasoning_deltas_parse_as_thinking() {
+        // Ollama 用 `reasoning`，DeepSeek/SiliconFlow 系用 `reasoning_content`；
+        // 两种拼写都必须归到 Thinking，而不是被当作空 content 丢弃。
+        let ollama = parse_sse_line(
+            "local",
+            r#"data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"想一想"},"finish_reason":null}]}"#,
+        );
+        assert!(matches!(ollama, Some(StreamContent::Thinking(ref s)) if s == "想一想"));
+
+        let deepseek = parse_sse_line(
+            "deepseek",
+            r#"data: {"choices":[{"index":0,"delta":{"content":null,"reasoning_content":"hmm"},"finish_reason":null}]}"#,
+        );
+        assert!(matches!(deepseek, Some(StreamContent::Thinking(ref s)) if s == "hmm"));
+
+        // 普通正文 chunk 不受影响
+        let text = parse_sse_line(
+            "local",
+            r#"data: {"choices":[{"index":0,"delta":{"content":"你好"},"finish_reason":null}]}"#,
+        );
+        assert!(matches!(text, Some(StreamContent::Text(ref s)) if s == "你好"));
+    }
+
+    #[test]
+    fn anthropic_thinking_delta_parses_as_thinking() {
+        let parsed = parse_sse_line(
+            "anthropic",
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}"#,
+        );
+        assert!(matches!(parsed, Some(StreamContent::Thinking(ref s)) if s == "Let me think"));
+    }
+
     fn image_message() -> ChatMessage {
         ChatMessage {
             id: "1".into(), role: "user".into(), content: "what is this".into(),
@@ -2629,7 +2767,7 @@ mod provider_tool_calling_tests {
         ).await.expect("continuation call should succeed");
 
         match outcome {
-            ContinuationResult::Text(text) => assert_eq!(text, "3加4等于7。"),
+            ContinuationResult::Text { text, .. } => assert_eq!(text, "3加4等于7。"),
             ContinuationResult::ToolCalls(_) => panic!("expected final text, got another tool-call request"),
         }
 
@@ -2690,7 +2828,7 @@ mod provider_tool_calling_tests {
             .expect("round 1 continuation");
         let next_calls = match outcome {
             ContinuationResult::ToolCalls(calls) => calls,
-            ContinuationResult::Text(_) => panic!("expected another tool call round"),
+            ContinuationResult::Text { .. } => panic!("expected another tool call round"),
         };
         assert_eq!(next_calls[0].id, "call_2");
 
@@ -2699,7 +2837,7 @@ mod provider_tool_calling_tests {
             .await
             .expect("round 2 continuation");
         match outcome_2 {
-            ContinuationResult::Text(text) => assert_eq!(text, "3+4=7，再乘以5等于35。"),
+            ContinuationResult::Text { text, .. } => assert_eq!(text, "3+4=7，再乘以5等于35。"),
             ContinuationResult::ToolCalls(_) => panic!("expected final text after 2 rounds"),
         }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.15",
+  "version": "0.2.0-beta.16",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -191,6 +191,18 @@ const handleCopy = async () => {
         class="message-body"
         :class="{ 'user-body': isUser }"
       >
+        <!-- 思考过程（思考型模型的 reasoning 流式增量；默认折叠，点击展开。
+             仅内存态展示，不写入正文、不入库，刷新后消失） -->
+        <details
+          v-if="message.thinking"
+          class="thinking-block"
+        >
+          <summary class="thinking-summary">
+            思考过程
+          </summary>
+          <pre class="thinking-content">{{ message.thinking }}</pre>
+        </details>
+
         <div
           ref="contentRef"
           class="markdown-content"
@@ -596,6 +608,40 @@ const handleCopy = async () => {
 
 .markdown-content :deep(tr:nth-child(even)) {
   background: $surface;
+}
+
+/* 思考过程折叠区 - 黑白灰 + 排版层次，与工具调用块同一视觉家族 */
+.thinking-block {
+  margin-bottom: 12px;
+  border: $border-faint;
+  background: $surface;
+}
+
+.thinking-summary {
+  padding: 6px 12px;
+  font-family: $font-mono;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: $ink-faint;
+  cursor: pointer;
+  user-select: none;
+  transition: color $duration $ease;
+
+  &:hover {
+    color: $ink;
+  }
+}
+
+.thinking-content {
+  margin: 0;
+  padding: 10px 12px;
+  border-top: $border-faint;
+  font-size: 12px;
+  line-height: $leading-body;
+  color: $ink-soft;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .streaming-indicator {

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -28,23 +28,11 @@ import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from "vue"
 // 导入 NaiveUI 组件
 import { NAvatar, NIcon, NSpin, NAlert, NTooltip } from "naive-ui";
 
-// 导入 Markdown 解析库
-import { marked } from "marked";
-
-// 导入 LaTeX 公式渲染扩展
-import markedKatex from "marked-katex-extension";
-import "katex/dist/katex.min.css";
-
-// 导入 HTML 净化库
-import DOMPurify from "dompurify";
-
-// 导入代码高亮库
-import hljs from "highlight.js";
-// 灰度高亮主题，契合黑白设计系统
-import "highlight.js/styles/grayscale.css";
-
-// 导入 Mermaid 图表库
-import mermaid from "mermaid";
+// Markdown 渲染管线。marked/KaTeX/DOMPurify/hljs/Mermaid 的全局配置都在该
+// 模块顶层完成，整个应用只执行一次——不能放回本组件的 <script setup>：
+// setup 顶层语句每挂载一条消息都会重新执行，会给全局单例反复叠加扩展/钩子，
+// 长会话下渲染越来越慢（详见 utils/markdown.ts 头部说明）。
+import { renderMarkdown, renderMermaidDiagrams } from "@/utils/markdown";
 
 // 导入消息类型
 import type { Message } from "@/stores/chat";
@@ -58,50 +46,13 @@ const props = defineProps<{
   message: Message;
 }>();
 
-// ============ Mermaid 初始化 ============
-
-mermaid.initialize({
-  startOnLoad: false,
-  // neutral 主题为灰度配色，契合黑白设计系统
-  theme: "neutral",
-  securityLevel: "loose",
-  fontFamily: '"Inter Variable", "Inter", system-ui, sans-serif',
-});
-
-// DOMPurify 默认的 URI 安全校验会把 srcdoc 这种"值不是 URL 而是一整段
-// HTML"的属性直接剥离，用 hook 强制放行 -- buildHtmlPreviewBlock 生成的
-// srcdoc 内容里的引号已经手动转义过，不依赖这里的校验来防属性逃逸。
-DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
-  if (data.attrName === "srcdoc") {
-    data.forceKeepAttr = true;
-  }
-});
-
 // ref 指向渲染 markdown 的 DOM 节点，用于查找 Mermaid 占位元素
 const contentRef = ref<HTMLElement | null>(null);
 
-// 唯一 ID 计数器，mermaid.render() 要求每次传不同 id
-let mermaidIdCounter = 0;
-
-/** 查找并渲染当前消息内所有待渲染的 Mermaid 占位块 */
-async function renderMermaidDiagrams() {
+/** 渲染当前消息内所有待渲染的 Mermaid 占位块 */
+async function renderPendingDiagrams() {
   if (!contentRef.value) return;
-  const pending = contentRef.value.querySelectorAll<HTMLElement>(
-    ".mermaid-diagram[data-pending='true']"
-  );
-  for (const el of pending) {
-    const code = decodeURIComponent(el.getAttribute("data-code") ?? "");
-    if (!code) continue;
-    el.setAttribute("data-pending", "false");
-    const id = `mermaid-${++mermaidIdCounter}`;
-    try {
-      const { svg } = await mermaid.render(id, code);
-      el.innerHTML = svg;
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      el.innerHTML = `<pre class="mermaid-error">图表渲染失败:\n${msg}</pre>`;
-    }
-  }
+  await renderMermaidDiagrams(contentRef.value);
 }
 
 // 流式输出结束后（streaming → false）渲染图表
@@ -110,7 +61,7 @@ watch(
   async (isStreaming) => {
     if (!isStreaming) {
       await nextTick();
-      renderMermaidDiagrams();
+      renderPendingDiagrams();
     }
   }
 );
@@ -119,7 +70,7 @@ watch(
 onMounted(async () => {
   if (!props.message.streaming) {
     await nextTick();
-    renderMermaidDiagrams();
+    renderPendingDiagrams();
   }
   window.addEventListener("message", handleHtmlPreviewMessage);
 });
@@ -172,147 +123,6 @@ function handleMarkdownClick(event: MouseEvent) {
   }
 }
 
-// ============ HTML 预览块生成 ============
-
-/**
- * 为 HTML 代码块生成"源码 + iframe 预览"双视图结构。
- * iframe 使用 sandbox + srcdoc 隔离执行，toolbar 按钮的点击由
- * handleMarkdownClick 事件委托处理（不用内联 onclick，会被 CSP 拦截）。
- */
-function buildHtmlPreviewBlock(code: string): string {
-  const highlighted = hljs.highlight(code, { language: "html" }).value;
-
-  // 如果模型只输出了 HTML 片段（非完整文档），补全基础框架以确保正确渲染
-  const isFullDoc = /^\s*<!doctype/i.test(code) || /^\s*<html[\s>]/i.test(code);
-  const docHtml = isFullDoc
-    ? code
-    : `<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{margin:16px;font-family:system-ui,sans-serif;line-height:1.6}</style></head><body>${code}</body></html>`;
-
-  // sandbox 不含 allow-same-origin（Issue #55：曾允许 iframe 内脚本靠
-  // allow-same-origin 逃出沙箱读父页面 localStorage）。iframe 因此是不透明源，
-  // 父页面无法用 contentDocument 读高度，改为在 iframe 内加载一个外部脚本文件，
-  // 通过 postMessage 主动上报高度（父页面处理见 handleHtmlPreviewMessage）。
-  // 必须是外部文件而不是内联 <script>：应用的 CSP 是精确哈希白名单（不含
-  // unsafe-inline/unsafe-hashes），且 srcdoc 文档会继承父页面 CSP，内联脚本
-  // 一律会被拦截静默失效；同源静态文件走 src= 加载则天然匹配 script-src 'self'。
-  // 闭合标签拆成两段字符串，避免在 .vue 的 <script> 块里出现完整闭合标签字面量。
-  const reporterTag = '<script src="/html-preview-reporter.js"></' + "script>";
-  const docWithReporter = /<\/body>/i.test(docHtml)
-    ? docHtml.replace(/<\/body>/i, `${reporterTag}</body>`)
-    : docHtml + reporterTag;
-
-  // srcdoc 属性值内只需转义 & 和 "
-  const srcdoc = docWithReporter.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
-
-  // 按钮不再用内联 onclick（同样会被 CSP 拦截），改为在 handleMarkdownClick 里
-  // 用事件委托处理 .html-preview-toggle 点击。
-  return (
-    `<div class="html-preview-block">` +
-    `<div class="html-preview-toolbar">` +
-    `<button class="html-preview-toggle">预览效果</button>` +
-    `<span class="html-lang-badge">HTML</span>` +
-    `</div>` +
-    `<pre class="html-source-pre"><code class="hljs language-html">${highlighted}</code></pre>` +
-    `<iframe class="html-preview-frame" srcdoc="${srcdoc}" ` +
-    `sandbox="allow-scripts allow-modals allow-forms"></iframe>` +
-    `</div>`
-  );
-}
-
-// ============ Mermaid 预览块生成 ============
-
-/**
- * 为 Mermaid 代码块生成"图表预览 + 源码"双视图结构。
- * 默认展示渲染后的图表（show-diagram 类），点击按钮切换。
- * 图表占位元素 data-pending="true"，由 renderMermaidDiagrams() 在 DOM 就绪后填充。
- */
-function buildMermaidPreviewBlock(code: string): string {
-  const highlighted = hljs.highlight(code, { language: "plaintext" }).value;
-  // encodeURIComponent 保证特殊字符在 data-* 属性里安全传递
-  const encoded = encodeURIComponent(code);
-
-  // 按钮不再用内联 onclick（CSP 会拦截），改为在 handleMarkdownClick 里事件委托处理。
-  return (
-    `<div class="mermaid-preview-block show-diagram">` +
-    `<div class="mermaid-toolbar">` +
-    `<button class="mermaid-toggle">查看源码</button>` +
-    `<span class="mermaid-lang-badge">Mermaid</span>` +
-    `</div>` +
-    `<pre class="mermaid-source-pre"><code class="hljs">${highlighted}</code></pre>` +
-    `<div class="mermaid-diagram" data-pending="true" data-code="${encoded}"></div>` +
-    `</div>`
-  );
-}
-
-// ============ Markdown 配置 ============
-
-// marked 默认把消息正文里出现的裸 HTML（不在围栏代码块内的）原样透传到输出，
-// 这里转义掉，防止 <script>/<img onerror>/<style> 等直接变成真实 DOM 节点。
-// 围栏代码块走的是下面的 code() 渲染器，不受影响。
-function escapeRawHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-// 不少模型（如 DeepSeek）输出 LaTeX 公式时用的是 \[...\] / \(...\) 定界符而非
-// $$...$$ / $...$。marked-katex-extension 只认后者；更麻烦的是 CommonMark 规则
-// 会把 "\[" "\]" 这类反斜杠+标点解析成转义序列（渲染为去掉反斜杠的纯标点），
-// 定界符在 marked 的分词阶段之前就已经丢失了。所以要在喂给 marked 之前，
-// 先把 \[...\] / \(...\) 正规化成 $$...$$ / $...$。
-function normalizeLatexDelimiters(text: string): string {
-  return text
-    .replace(/\\\[([\s\S]*?)\\\]/g, (_match, expr: string) => `$$${expr}$$`)
-    .replace(/\\\(([\s\S]*?)\\\)/g, (_match, expr: string) => `$${expr}$`);
-}
-
-// 使用单例确保 marked.use() 只调用一次（marked 修改全局实例）
-const markedInitPromise = (() => {
-  let promise: Promise<void> | null = null;
-  return () => {
-    if (!promise) {
-      promise = new Promise((resolve) => {
-        // 黑白设计系统下不用 KaTeX 默认的红色报错色，退化为普通灰字
-        marked.use(markedKatex({ throwOnError: false, errorColor: "#444444" }));
-        marked.use({
-          renderer: {
-            // 消息正文中的裸 HTML（块级或内联）一律转义为纯文本
-            html(html: string, _block?: boolean): string {
-              return escapeRawHtml(html);
-            },
-            // 处理所有围栏代码块（三参数形式是此版本 marked 的 Renderer 签名）
-            code(text: string, lang: string | undefined, _escaped: boolean): string {
-              // 取 info string 第一个单词作为语言标识（如 "html filename.html" → "html"）
-              const normalizedLang = ((lang ?? "").trim().split(/\s+/)[0] ?? "").toLowerCase();
-
-              if (normalizedLang === "html" || normalizedLang === "htm") {
-                return buildHtmlPreviewBlock(text);
-              }
-
-              if (normalizedLang === "mermaid") {
-                return buildMermaidPreviewBlock(text);
-              }
-
-              // 其余语言走 highlight.js 常规高亮
-              const language = hljs.getLanguage(normalizedLang) ? normalizedLang : "plaintext";
-              const highlighted = hljs.highlight(text, { language }).value;
-              return `<pre><code class="hljs language-${language}">${highlighted}</code></pre>`;
-            },
-          },
-        });
-        resolve();
-      });
-    }
-    return promise;
-  };
-})();
-
-// 初始化 marked 配置
-markedInitPromise();
-
 // ============ 计算属性 ============
 
 // 是否为用户消息
@@ -321,23 +131,9 @@ const isUser = computed(() => props.message.role === "user");
 // 是否为 AI 助手消息
 const isAssistant = computed(() => props.message.role === "assistant");
 
-// 渲染后的 Markdown 内容
-// 二次防线：即便 marked 的转义有疏漏，DOMPurify 仍会按白名单剥离危险标签/属性。
-// iframe/sandbox/srcdoc 是 buildHtmlPreviewBlock 生成的沙箱预览所必需的，显式放行。
-const renderedContent = computed(() => {
-  if (!props.message.content) return "";
-  const normalized = normalizeLatexDelimiters(props.message.content);
-  const html = marked.parse(normalized, { async: false, breaks: true }) as string;
-  return DOMPurify.sanitize(html, {
-    ADD_TAGS: ["iframe"],
-    ADD_ATTR: ["sandbox", "srcdoc"],
-    // srcdoc's value is a full HTML document (it legitimately contains
-    // "</style>" etc.), which DOMPurify's SAFE_FOR_XML close-tag probe
-    // otherwise treats as an attribute-escape attempt and strips outright.
-    // The uponSanitizeAttribute hook above is what actually keeps srcdoc.
-    SAFE_FOR_XML: false,
-  });
-});
+// 渲染后的 Markdown 内容（解析、净化、HTML/Mermaid 预览块生成全部在
+// utils/markdown.ts 的 renderMarkdown 里完成）
+const renderedContent = computed(() => renderMarkdown(props.message.content));
 
 // ============ 方法函数 ============
 
@@ -398,8 +194,8 @@ const handleCopy = async () => {
         <div
           ref="contentRef"
           class="markdown-content"
-          v-html="renderedContent"
           @click="handleMarkdownClick"
+          v-html="renderedContent"
         />
         
         <!-- Streaming indicator -->

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@
 import { createApp, type Directive } from "vue";
 import { createPinia } from "pinia";
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
+import { open as openExternalUrl } from "@tauri-apps/plugin-shell";
 import router from "./router";
 import App from "./App.vue";
 
@@ -62,6 +63,38 @@ const vReveal: Directive<HTMLElement, number | undefined> = {
     revealObserver.unobserve(el);
   },
 };
+
+/**
+ * 全局外链拦截
+ *
+ * WebView 里点击 <a href="https://..."> 默认会让整个应用窗口导航去外部网站
+ * ——界面被顶掉且没有任何返回手段，只能杀进程重开（聊天消息里模型输出的
+ * Markdown 链接实测踩过）。LocalDeployView/SettingsView 各自给自己的链接
+ * 调过 plugin-shell 的 open()，但 v-html 渲染出的 Markdown 链接没人管。
+ * 这里在捕获阶段统一拦截：凡是指向应用自身源之外的 http/https 链接，
+ * 一律阻止 WebView 导航、转交系统默认浏览器打开。
+ */
+document.addEventListener(
+  "click",
+  (event) => {
+    const anchor = (event.target as HTMLElement | null)?.closest?.("a[href]");
+    if (!anchor) return;
+    const href = anchor.getAttribute("href") ?? "";
+    if (!/^https?:\/\//i.test(href)) return;
+    let sameOrigin = false;
+    try {
+      sameOrigin = new URL(href).host === location.host;
+    } catch {
+      return;
+    }
+    if (sameOrigin) return;
+    event.preventDefault();
+    openExternalUrl(href).catch((err) => {
+      console.error("Failed to open external url:", href, err);
+    });
+  },
+  { capture: true },
+);
 
 // 创建 Pinia 实例
 const pinia = createPinia();

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -13,7 +13,6 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useSettingsStore } from "./settings";
 import { useKnowledgeBaseStore, type RetrievalResult } from "./knowledgeBase";
-import { useMCPStore, type MCPTool } from "./mcp";
 import { classifyError } from "@/utils/errorMessage";
 
 /** 图片附件（base64 编码，不含 data URL 前缀） */
@@ -490,93 +489,6 @@ export const useChatStore = defineStore("chat", () => {
   };
 
   /**
-   * 执行 MCP 工具调用
-   * 
-   * @param toolName - 工具名称
-   * @param toolInput - 工具输入参数
-   * @returns 工具执行结果 (字符串格式)
-   */
-  const executeMcpTool = async (toolName: string, toolInput: Record<string, unknown>): Promise<string> => {
-    const mcp = useMCPStore();
-    const tool = mcp.availableTools.find(t => t.name === toolName);
-    
-    if (!tool) {
-      return `错误: 工具 "${toolName}" 不存在`;
-    }
-
-    try {
-      // 调用后端 MCP 命令执行工具
-      const result = await invoke<any>("call_mcp_tool", {
-        toolName,
-        input: toolInput,
-      });
-
-      // 检查返回结果中的 success 标志
-      if (typeof result === 'object' && result !== null) {
-        const resultObj = result as Record<string, unknown>;
-        const anyRes = result as any;
-        
-        // 处理错误标志
-        if ('success' in resultObj) {
-          if (anyRes.success === false && anyRes.error) {
-            return `工具执行失败: ${anyRes.error}`;
-          }
-        }
-
-        // 提取结果字段
-        if ('result' in resultObj) {
-          return JSON.stringify(anyRes.result, null, 2);
-        }
-        
-        // 如果没有特定结果字段，返回整个响应
-        return JSON.stringify(anyRes, null, 2);
-      } else {
-        return String(result);
-      }
-    } catch (err) {
-      return `调用工具时出错: ${String(err)}`;
-    }
-  };
-
-  /**
-   * 处理助手消息中的 MCP 工具调用
-   * 从响应中解析工具调用指令并执行
-   * 
-   * @param assistantMessage - 助手消息对象
-   * @returns void
-   */
-  const handleMcpCalls = async (assistantMessage: Message): Promise<void> => {
-    const mcp = useMCPStore();
-    // 如果 MCP 未启用或没有可用工具，直接返回
-    if (!mcpEnabled.value || mcp.availableTools.length === 0) return;
-
-    // 简单的模式匹配来检测工具调用
-    // 格式: [使用工具: tool_name with input: {...}]
-    const toolCallPattern = /\[使用工具: ([\w_-]+) with input: ({[^}]+})\]/g;
-    const matches = Array.from(assistantMessage.content.matchAll(toolCallPattern));
-
-    if (matches.length === 0) return; // 未检测到工具调用
-
-    // 执行每个工具调用并收集结果
-    const toolResults: string[] = [];
-    for (const match of matches) {
-      const toolName = match[1];
-      try {
-        const toolInput = JSON.parse(match[2]) as Record<string, unknown>;
-        const result = await executeMcpTool(toolName, toolInput);
-        toolResults.push(`[工具 ${toolName} 结果]: ${result}`);
-      } catch (err) {
-        toolResults.push(`[工具 ${toolName} 错误]: ${String(err)}`);
-      }
-    }
-
-    // 如果执行了工具，将结果追加到助手消息
-    if (toolResults.length > 0) {
-      assistantMessage.content += "\n\n" + toolResults.join("\n");
-    }
-  };
-
-  /**
    * 发送消息 (核心函数)
    * 处理用户消息发送、LLM 调用、流式响应等完整流程
    *
@@ -617,8 +529,6 @@ export const useChatStore = defineStore("chat", () => {
       alert("API 密钥未加载，请重启应用或重新设置");
       return;
     }
-
-    const mcp = useMCPStore();
 
     // 初始化内容变量
     let enhancedContent = content;
@@ -737,31 +647,10 @@ export const useChatStore = defineStore("chat", () => {
         }
       }
 
-      // ============ MCP 系统提示 ============
-      if (mcpEnabled.value && mcp.availableTools.length > 0) {
-        const mcpSystemPrompt = buildMcpSystemPrompt(mcp.availableTools);
-        
-        // 如果已有系统消息，追加 MCP 信息
-        if (apiMessages.length > 0 && apiMessages[0].role === "system") {
-          apiMessages[0] = {
-            ...apiMessages[0],
-            content: apiMessages[0].content + "\n\n" + mcpSystemPrompt,
-          };
-        } else {
-          // 在开头插入新的系统消息
-          apiMessages.unshift({
-            id: crypto.randomUUID(),
-            role: "system",
-            content: mcpSystemPrompt,
-            timestamp: Date.now(),
-            error: undefined,
-            images: [],
-            videos: [],
-          });
-        }
-      }
-
       // ============ 构建请求 payload ============
+      // MCP 工具不再以文本形式塞进 system prompt——后端会在 enableMcp 开启时
+      // 通过各 provider 的原生 tools 字段声明工具并执行多轮调用循环，前端
+      // 再注入一份 JSON 文本只会让每轮请求重复付一份 token。
       const requestPayload = {
         sessionId: currentSession.value.id,
         messages: apiMessages,
@@ -804,12 +693,6 @@ export const useChatStore = defineStore("chat", () => {
         console.error('[sendMessage] stream_message error:', e);
         if (import.meta.env.DEV) console.error('stream_message error', e);
         throw e;
-      }
-
-      // ============ 处理 MCP 工具调用 ============
-      const assistantMsgRef = currentSession.value.messages[currentSession.value.messages.length - 1];
-      if (assistantMsgRef.role === "assistant") {
-        await handleMcpCalls(assistantMsgRef);
       }
 
       // ============ 更新会话标题 ============
@@ -874,55 +757,6 @@ export const useChatStore = defineStore("chat", () => {
     
     contextParts.push("\n---");
     return contextParts.join("\n");
-  };
-
-  /**
-   * 构建 MCP 工具定义
-   * 将可用工具格式化为 JSON 字符串，用于系统提示
-   * 
-   * @param availableTools - 可用的 MCP 工具列表
-   * @returns 格式化的工具定义字符串
-   */
-  const buildMcpToolDefinitions = (availableTools: MCPTool[]): string => {
-    if (availableTools.length === 0) return "";
-
-    const toolsJson = availableTools.map((tool) => ({
-      type: "function",
-      function: {
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.input_schema,
-      },
-    }));
-
-    const toolDefString = JSON.stringify(toolsJson, null, 2);
-    
-    return `## 可用工具
-
-你可以使用以下工具来完成任务。每个工具都有特定的功能和参数要求。
-
-\`\`\`json
-${toolDefString}
-\`\`\`
-
-使用工具时，你可以调用它们来获取信息或执行操作。`;
-  };
-
-  /**
-   * 构建 MCP 系统提示
-   * 包含工具定义和如何使用工具的说明
-   * 
-   * @param availableTools - 可用的 MCP 工具列表
-   * @returns 系统提示字符串
-   */
-  const buildMcpSystemPrompt = (availableTools: MCPTool[]): string => {
-    const toolDefs = buildMcpToolDefinitions(availableTools);
-    
-    return `你是一个有能力的AI助手，可以使用各种工具来帮助用户完成任务。
-
-${toolDefs}
-
-当你需要使用工具时，请清楚地说明你打算使用哪个工具以及为什么。你可以组合多个工具来解决更复杂的问题。`;
   };
 
   /**
@@ -1051,7 +885,6 @@ ${toolDefs}
     toggleRag,               // 切换 RAG
     selectKnowledgeBaseForRag,  // 选择知识库
     classifyError,           // 错误分类
-    executeMcpTool,         // 执行 MCP 工具
     stopStream,              // 停止流式输出
   };
 });

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -37,6 +37,7 @@ export interface Message {
   content: string;               // 消息内容
   timestamp: number;              // 时间戳 (毫秒)
   streaming?: boolean;            // 是否正在流式输出
+  thinking?: string;              // 思考过程（思考型模型的 reasoning 增量累积，仅内存态、不入库）
   error?: string;                 // 错误信息 (如果有)
   files?: Array<{                // 附件文件列表
     name: string;                 // 文件名
@@ -79,6 +80,7 @@ interface StreamChunk {
   session_id: string;             // 所属会话 ID
   message_id: string;             // 消息 ID
   content: string;                // 增量内容
+  is_thinking?: boolean;          // 是否思考过程增量（归到 thinking 字段而非正文）
   done: boolean;                  // 是否完成
 }
 
@@ -289,10 +291,14 @@ export const useChatStore = defineStore("chat", () => {
         return;
       }
 
-      // 累加内容 (打字机效果)
-      lastMessage.content += chunk.content;
-      currentStreamContent.value = lastMessage.content;
-      console.log("[Stream] Updated content, length:", lastMessage.content.length);
+      // 累加内容 (打字机效果)。思考型模型的思考增量单独归到 thinking 字段，
+      // 由 ChatMessage.vue 的"思考过程"折叠区展示，不混入正文、也不入库
+      if (chunk.is_thinking) {
+        lastMessage.thinking = (lastMessage.thinking ?? "") + chunk.content;
+      } else {
+        lastMessage.content += chunk.content;
+        currentStreamContent.value = lastMessage.content;
+      }
     });
   };
 
@@ -313,7 +319,13 @@ export const useChatStore = defineStore("chat", () => {
       if (!currentSession.value) return;
       if (String(evt.session_id) !== String(currentSession.value.id)) return;
 
-      const message = currentSession.value.messages.find(m => m.id === evt.message_id);
+      // 后端在 stream_message 里自行生成 message_id，与前端占位 assistant
+      // 消息的 id 并不相同（文本流的 stream-chunk 监听器同样只按 session
+      // 匹配，所以文本不受影响）。按 id 找不到时回退到最后一条 assistant
+      // 消息——否则工具调用状态永远挂不上任何消息，工具明明执行了，界面
+      // 上却看不到"调用中/已完成"。
+      const message = currentSession.value.messages.find(m => m.id === evt.message_id)
+        ?? [...currentSession.value.messages].reverse().find(m => m.role === "assistant");
       if (!message) return;
 
       if (!message.toolCalls) {
@@ -656,7 +668,10 @@ export const useChatStore = defineStore("chat", () => {
         messages: apiMessages,
         provider: config.provider,
         model: config.model,
-        apiKey: config.apiKey,
+        // 持久化会剥掉 apiKey，重启后 keyring 里没有条目的配置（本地模型）读到
+        // 的是 undefined——必须兜底成空串，否则 invoke 参数反序列化直接报
+        // "missing field apiKey"。空串对后端是合法值（本地免鉴权/keyring 兜底）。
+        apiKey: config.apiKey ?? "",
         baseUrl: config.baseUrl,
         enableMcp: mcpEnabled.value,
         activeSkillIds: activeSkillIds.value,

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,202 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// 聊天消息的 Markdown 渲染管线（marked 配置、HTML/Mermaid 预览块、DOMPurify
+// 净化、Mermaid 图表渲染）。
+//
+// 必须放在独立模块而不是 ChatMessage.vue 的 <script setup> 里：setup 块的
+// 顶层语句会在**每个组件实例创建时**执行，而 marked.use() / DOMPurify.addHook()
+// / mermaid.initialize() 改的都是全局单例——放在组件里意味着每挂载一条消息
+// 就给 marked 多包一层扩展、给 DOMPurify 多挂一个重复钩子，长会话下 Markdown
+// 解析会一条比一条慢。模块顶层代码在整个应用生命周期里只执行一次。
+
+import { marked } from "marked";
+import markedKatex from "marked-katex-extension";
+import "katex/dist/katex.min.css";
+import DOMPurify from "dompurify";
+import hljs from "highlight.js";
+// 灰度高亮主题，契合黑白设计系统
+import "highlight.js/styles/grayscale.css";
+import mermaid from "mermaid";
+
+mermaid.initialize({
+  startOnLoad: false,
+  // neutral 主题为灰度配色，契合黑白设计系统
+  theme: "neutral",
+  securityLevel: "loose",
+  fontFamily: '"Inter Variable", "Inter", system-ui, sans-serif',
+});
+
+// DOMPurify 默认的 URI 安全校验会把 srcdoc 这种"值不是 URL 而是一整段
+// HTML"的属性直接剥离，用 hook 强制放行 -- buildHtmlPreviewBlock 生成的
+// srcdoc 内容里的引号已经手动转义过，不依赖这里的校验来防属性逃逸。
+DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
+  if (data.attrName === "srcdoc") {
+    data.forceKeepAttr = true;
+  }
+});
+
+/**
+ * 为 HTML 代码块生成"源码 + iframe 预览"双视图结构。
+ * iframe 使用 sandbox + srcdoc 隔离执行，toolbar 按钮的点击由
+ * ChatMessage.vue 的事件委托处理（不用内联 onclick，会被 CSP 拦截）。
+ */
+function buildHtmlPreviewBlock(code: string): string {
+  const highlighted = hljs.highlight(code, { language: "html" }).value;
+
+  // 如果模型只输出了 HTML 片段（非完整文档），补全基础框架以确保正确渲染
+  const isFullDoc = /^\s*<!doctype/i.test(code) || /^\s*<html[\s>]/i.test(code);
+  const docHtml = isFullDoc
+    ? code
+    : `<!DOCTYPE html><html><head><meta charset="utf-8"><style>body{margin:16px;font-family:system-ui,sans-serif;line-height:1.6}</style></head><body>${code}</body></html>`;
+
+  // sandbox 不含 allow-same-origin（Issue #55：曾允许 iframe 内脚本靠
+  // allow-same-origin 逃出沙箱读父页面 localStorage）。iframe 因此是不透明源，
+  // 父页面无法用 contentDocument 读高度，改为在 iframe 内加载一个外部脚本文件，
+  // 通过 postMessage 主动上报高度（父页面处理见 ChatMessage.vue 的
+  // handleHtmlPreviewMessage）。
+  // 必须是外部文件而不是内联 <script>：应用的 CSP 是精确哈希白名单（不含
+  // unsafe-inline/unsafe-hashes），且 srcdoc 文档会继承父页面 CSP，内联脚本
+  // 一律会被拦截静默失效；同源静态文件走 src= 加载则天然匹配 script-src 'self'。
+  // 闭合标签拆成两段字符串，避免源文件里出现完整闭合标签字面量被工具误判。
+  const reporterTag = '<script src="/html-preview-reporter.js"></' + "script>";
+  const docWithReporter = /<\/body>/i.test(docHtml)
+    ? docHtml.replace(/<\/body>/i, `${reporterTag}</body>`)
+    : docHtml + reporterTag;
+
+  // srcdoc 属性值内只需转义 & 和 "
+  const srcdoc = docWithReporter.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+
+  // 按钮不用内联 onclick（会被 CSP 拦截），由 ChatMessage.vue 里
+  // handleMarkdownClick 用事件委托处理 .html-preview-toggle 点击。
+  return (
+    `<div class="html-preview-block">` +
+    `<div class="html-preview-toolbar">` +
+    `<button class="html-preview-toggle">预览效果</button>` +
+    `<span class="html-lang-badge">HTML</span>` +
+    `</div>` +
+    `<pre class="html-source-pre"><code class="hljs language-html">${highlighted}</code></pre>` +
+    `<iframe class="html-preview-frame" srcdoc="${srcdoc}" ` +
+    `sandbox="allow-scripts allow-modals allow-forms"></iframe>` +
+    `</div>`
+  );
+}
+
+/**
+ * 为 Mermaid 代码块生成"图表预览 + 源码"双视图结构。
+ * 默认展示渲染后的图表（show-diagram 类），点击按钮切换。
+ * 图表占位元素 data-pending="true"，由 renderMermaidDiagrams() 在 DOM 就绪后填充。
+ */
+function buildMermaidPreviewBlock(code: string): string {
+  const highlighted = hljs.highlight(code, { language: "plaintext" }).value;
+  // encodeURIComponent 保证特殊字符在 data-* 属性里安全传递
+  const encoded = encodeURIComponent(code);
+
+  return (
+    `<div class="mermaid-preview-block show-diagram">` +
+    `<div class="mermaid-toolbar">` +
+    `<button class="mermaid-toggle">查看源码</button>` +
+    `<span class="mermaid-lang-badge">Mermaid</span>` +
+    `</div>` +
+    `<pre class="mermaid-source-pre"><code class="hljs">${highlighted}</code></pre>` +
+    `<div class="mermaid-diagram" data-pending="true" data-code="${encoded}"></div>` +
+    `</div>`
+  );
+}
+
+// marked 默认把消息正文里出现的裸 HTML（不在围栏代码块内的）原样透传到输出，
+// 这里转义掉，防止 <script>/<img onerror>/<style> 等直接变成真实 DOM 节点。
+// 围栏代码块走的是下面的 code() 渲染器，不受影响。
+function escapeRawHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// 不少模型（如 DeepSeek）输出 LaTeX 公式时用的是 \[...\] / \(...\) 定界符而非
+// $$...$$ / $...$。marked-katex-extension 只认后者；更麻烦的是 CommonMark 规则
+// 会把 "\[" "\]" 这类反斜杠+标点解析成转义序列（渲染为去掉反斜杠的纯标点），
+// 定界符在 marked 的分词阶段之前就已经丢失了。所以要在喂给 marked 之前，
+// 先把 \[...\] / \(...\) 正规化成 $$...$$ / $...$。
+function normalizeLatexDelimiters(text: string): string {
+  return text
+    .replace(/\\\[([\s\S]*?)\\\]/g, (_match, expr: string) => `$$${expr}$$`)
+    .replace(/\\\(([\s\S]*?)\\\)/g, (_match, expr: string) => `$${expr}$`);
+}
+
+// marked.use() 修改的是全局 marked 实例，模块顶层保证整个应用只配置一次。
+// 黑白设计系统下不用 KaTeX 默认的红色报错色，退化为普通灰字
+marked.use(markedKatex({ throwOnError: false, errorColor: "#444444" }));
+marked.use({
+  renderer: {
+    // 消息正文中的裸 HTML（块级或内联）一律转义为纯文本
+    html(html: string, _block?: boolean): string {
+      return escapeRawHtml(html);
+    },
+    // 处理所有围栏代码块（三参数形式是此版本 marked 的 Renderer 签名）
+    code(text: string, lang: string | undefined, _escaped: boolean): string {
+      // 取 info string 第一个单词作为语言标识（如 "html filename.html" → "html"）
+      const normalizedLang = ((lang ?? "").trim().split(/\s+/)[0] ?? "").toLowerCase();
+
+      if (normalizedLang === "html" || normalizedLang === "htm") {
+        return buildHtmlPreviewBlock(text);
+      }
+
+      if (normalizedLang === "mermaid") {
+        return buildMermaidPreviewBlock(text);
+      }
+
+      // 其余语言走 highlight.js 常规高亮
+      const language = hljs.getLanguage(normalizedLang) ? normalizedLang : "plaintext";
+      const highlighted = hljs.highlight(text, { language }).value;
+      return `<pre><code class="hljs language-${language}">${highlighted}</code></pre>`;
+    },
+  },
+});
+
+/**
+ * 把消息正文渲染成净化后的 HTML。
+ * 二次防线：即便 marked 的转义有疏漏，DOMPurify 仍会按白名单剥离危险标签/属性。
+ * iframe/sandbox/srcdoc 是 buildHtmlPreviewBlock 生成的沙箱预览所必需的，显式放行。
+ */
+export function renderMarkdown(content: string): string {
+  if (!content) return "";
+  const normalized = normalizeLatexDelimiters(content);
+  const html = marked.parse(normalized, { async: false, breaks: true }) as string;
+  return DOMPurify.sanitize(html, {
+    ADD_TAGS: ["iframe"],
+    ADD_ATTR: ["sandbox", "srcdoc"],
+    // srcdoc's value is a full HTML document (it legitimately contains
+    // "</style>" etc.), which DOMPurify's SAFE_FOR_XML close-tag probe
+    // otherwise treats as an attribute-escape attempt and strips outright.
+    // The uponSanitizeAttribute hook above is what actually keeps srcdoc.
+    SAFE_FOR_XML: false,
+  });
+}
+
+// 唯一 ID 计数器，mermaid.render() 要求每次传不同 id；模块级保证全局唯一
+let mermaidIdCounter = 0;
+
+/** 查找并渲染容器内所有待渲染的 Mermaid 占位块 */
+export async function renderMermaidDiagrams(container: HTMLElement): Promise<void> {
+  const pending = container.querySelectorAll<HTMLElement>(
+    ".mermaid-diagram[data-pending='true']"
+  );
+  for (const el of pending) {
+    const code = decodeURIComponent(el.getAttribute("data-code") ?? "");
+    if (!code) continue;
+    el.setAttribute("data-pending", "false");
+    const id = `mermaid-${++mermaidIdCounter}`;
+    try {
+      const { svg } = await mermaid.render(id, code);
+      el.innerHTML = svg;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      el.innerHTML = `<pre class="mermaid-error">图表渲染失败:\n${msg}</pre>`;
+    }
+  }
+}


### PR DESCRIPTION
## 背景

对 Chat 相关模块（ChatView / chat.ts / ChatMessage / ChatInput / llm.rs）做了一轮简洁性与可维护性审核并修复确认的两项；随后按用户要求继续修复了测试中发现的既有运行时缺陷。共两个 commit：

## Commit 1（ce75f09）：模块清理

**改动一：删除 chat.ts 遗留的 MCP 文本匹配层（净删约 170 行）**
后端原生工具调用循环上线后，旧版靠正则从回复文本里抓 `[使用工具: ...]` 的方案已匹配不到任何真实输出，属于死代码；但它每轮请求仍把全部 MCP 工具定义以 JSON 文本塞进 system prompt，与后端原生 `tools` 字段重复声明、双份耗 token。`mcpEnabled` 开关与原生路径保留不动。

**改动二：Markdown 渲染管线提升为模块级单例（ChatMessage.vue 瘦身约 230 行）**
`<script setup>` 顶层语句每个组件实例都会执行，而 `marked.use()` / `DOMPurify.addHook()` / `mermaid.initialize()` 改的都是全局单例——每挂载一条消息就叠加一层扩展/钩子，症状是聊得越久渲染越卡、重启恢复。整条管线迁移到新文件 `src/utils/markdown.ts` 的模块作用域，应用生命周期内只初始化一次。

**版本**：`0.2.0-beta.15` → `0.2.0-beta.16`（三处同步）。

## Commit 2（1d204f7）：四处运行时缺陷修复

1. **思考型模型经 local provider 空回复 + 工具调用被吞（同一处解析的两个缺陷）**：OpenAI 兼容分支的 SSE 解析先匹配 `delta.content`——Ollama 在携带 `tool_calls` 的 chunk 里同时带 `"content":""`，空串命中后直接返回，**同一 chunk 的 tool_calls 被整个吞掉**；思考增量（Ollama `delta.reasoning` / DeepSeek 系 `reasoning_content`）则被静默丢弃。解析顺序改为 tool_calls → 正文 → 思考；思考增量以 `is_thinking` 标记转发，消息气泡新增黑白风格"思考过程"折叠区（Anthropic `thinking_delta`、工具续写非流式响应里的 reasoning 一并接入）。
2. **本地配置重启后发消息报 `missing field apiKey`**：settings 持久化剥掉 apiKey、本地配置在 keyring 无条目可回填。`SendMessageRequest.api_key` 加 `#[serde(default)]`，前端 payload 兜底空串。
3. **消息里的外链把整个应用窗口带走**（用户实测踩到）：`v-html` 渲染的 Markdown 链接点击后 WebView 直接导航去外部网站且无返回手段。`main.ts` 挂全局捕获段拦截器，非应用源的 http/https 链接一律转交系统默认浏览器（复用 LocalDeployView/SettingsView 已用的 plugin-shell `open()`）。
4. **工具调用状态条永远不显示**：后端 `stream_message` 自生成的 `message_id` 与前端占位消息 id 不同，`tool-call-status` 事件按 id 找消息永远落空。按 id 找不到时回退到最后一条 assistant 消息（与文本流监听器的按 session 匹配策略一致）。

## 验证

- 后端 27 个单元测试通过（含 4 个新增：空串不吞 tool_calls、reasoning 双拼写解析、thinking_delta、正文不受影响）；`pnpm build` / `cargo check` / `pnpm tauri build` 全部通过（updater 签名一步因本机无私钥跳过，与代码无关）。
- 真机测试（release 构建 + CDP driver + 本地 Ollama qwen3.5:4b / gemma4:e4b）：
  - 渲染管线：代码高亮 / KaTeX / Mermaid SVG / 无裸 script 泄漏 ✓
  - 思考型模型：思考 8691 字符进折叠区 + 正文 4822 字符正常渲染（修复前为空气泡）✓
  - 无 apiKey 配置发送成功（修复前必报 missing field）✓
  - MCP 完整链路：思考 → `builtin__fetch_url` 调用 → 状态条"已完成"（含参数与结果）→ 续写正文 256 字符（修复前：工具调用被吞、状态条不显示）✓
  - 外链点击：应用停留原界面，系统浏览器打开目标页（修复前：窗口被带走无法返回）✓
  - 测试会话与临时配置已全部清理复原。

## 已知残留（记录，不在本 PR 处理)

- 思考型小模型偶发把全部输出耗在思考里（含工具续写轮），此时正文为空但思考过程可见，用户能看到模型的实际行为——属模型行为而非解析缺陷。
- 会话从数据库重载后思考过程不保留（thinking 仅内存态，不入库）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)