### PR TITLE
fix: Agent 工具轮配额耗尽时强制无工具收尾轮，日报助手不再整轮空转

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.16",
+  "version": "0.2.0-beta.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.16"
+version = "0.2.0-beta.17"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -1148,13 +1148,66 @@ async fn process_agent_wake(
         }
     }
 
-    if !produced_final_text {
+    if !produced_final_text && !cancel.is_cancelled() {
         log::warn!(
-            "Workspace agent {} 在轮数上限内没有给出最终回复，提前结束本次唤醒（计数 {} 轮 / 总 {} 轮）",
+            "Workspace agent {} 在轮数上限内没有给出最终回复，进入无工具强制收尾轮（计数 {} 轮 / 总 {} 轮）",
             agent_id,
             counted_rounds,
             total_rounds
         );
+        // 强制交卷轮：此前工具轮配额烧完就直接结束，整轮唤醒的成果原地蒸发
+        // ——已抓取的所有工具结果被丢弃，工作区一条消息都收不到（日报助手
+        // 实测：8 轮全花在逐个 fetch 网页上，报告永远写不出来）。这里追加
+        // 一条明确的"预算用完，立即交卷"指令，再跑一轮**不带任何工具**的
+        // 推理：请求里没有 tools 字段，模型没有再发起调用的原生手段，只能
+        // 基于已经拿到的结果给出文字回复。
+        let nudge = ChatMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            role: "user".to_string(),
+            content: "【系统】本次唤醒的工具调用配额已用完。请立即基于以上已获得的全部工具结果，直接给出你的最终回复；如信息不完整，说明还缺什么即可，不要再尝试调用任何工具。".to_string(),
+            timestamp: chrono::Utc::now().timestamp_millis(),
+            error: None,
+            images: vec![],
+            videos: vec![],
+        };
+        native_messages.extend(build_native_messages(&agent.provider, std::slice::from_ref(&nudge)));
+
+        match run_turn(
+            &agent.provider,
+            &agent.model,
+            &api_key,
+            &agent.base_url,
+            Some(&system_prompt),
+            &native_messages,
+            &[],
+            None,
+            agent.enable_thinking,
+        )
+        .await
+        {
+            Ok(TurnOutcome::Text(text)) if !text.trim().is_empty() => {
+                log::info!(
+                    "[workspace] Agent「{}」强制收尾轮产出回复 ({} 字符)",
+                    agent.name,
+                    text.len()
+                );
+                append_text_reply(&agent.provider, &mut native_messages, &text);
+                send_workspace_message(app_handle, workspace_id, agent_id, "user", &text).await;
+            }
+            Ok(TurnOutcome::Text(_)) => {
+                log::warn!("[workspace] Agent「{}」强制收尾轮仍未产出内容", agent.name);
+            }
+            Ok(TurnOutcome::ToolCalls(_)) => {
+                // 请求里没给 tools 字段，正常到不了这里；真到了也只记录，不再执行
+                log::warn!(
+                    "[workspace] Agent「{}」强制收尾轮仍试图调用工具，放弃本次唤醒",
+                    agent.name
+                );
+            }
+            Err(e) => {
+                log::warn!("[workspace] Agent「{}」强制收尾轮请求失败: {}", agent.name, e);
+            }
+        }
     }
 
     // 别覆盖掉 Sleeping（由 workspace_sleep 设置）、Meeting（由会议协调器

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.16",
+  "version": "0.2.0-beta.17",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 问题（规划清单第 1 项）

Workspace Agent 的唤醒循环里，`MAX_ROUNDS_PER_WAKE = 8` 的工具轮配额烧完后直接结束唤醒：**已抓取的全部工具结果被丢弃，工作区一条消息都收不到**。「日报助手」2026-07-17 两次唤醒实测全花在逐个 `builtin__fetch_url` 抓网页上（天气多城市 + HN + 博客 > 8 个目标），轮数耗尽即被掐断，日报永远写不出来、整轮空转还白付 API token。

**人话**：实习生领了 8 次外出调研的额度，全用来跑腿了，还没来得及写报告就被赶下班，采访笔记还被没收——现在改成下班前必须先交稿。

## 修法

配额耗尽且未产出最终回复时，追加一条"预算用完，立即基于已有结果交卷"的用户指令，再跑一轮**不携带 `tools` 字段**的 `run_turn`——模型没有再发起工具调用的原生手段，只能基于已获得的结果给出文字回复。含取消状态保护与失败降级（收尾轮失败只记日志，不影响状态复位）。

不动 8 轮上限本身；按 Agent 可配置轮数上限留作后续增强。

## 验证

- `cargo test` 全量 45 个测试通过；`cargo check` / `pnpm build` / `pnpm tauri build` 通过（updater 签名步骤因本机无私钥跳过，与代码无关）。
- 真机验证（release 构建 + 本地 Ollama）：
  - 合成用例：临时工作组 + qwen3.5:4b Agent 抓 9 个 URL——该轮模型自行提前交卷，未触发强制收尾（属正常路径不受影响的佐证）；
  - **生产用例（决定性证据）**：用户真实的「日报助手」（moonshot/kimi-k3）在修复后的构建里按自身调度唤醒，照旧烧完 8 轮配额，随后由强制收尾轮产出 **4343 字符**的日报回复并送达工作区——正是昨天连续空转的同一个 Agent、同一套配置。
  - 测试工作组已删除，数据复原。

版本号 `0.2.0-beta.16` → `0.2.0-beta.17`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)