### PR TITLE
fix: Workspace 空回复不再静默丢失 + 本地服务思考开关真正生效（LM Studio TTFT 根治）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.18",
+  "version": "0.2.0-beta.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.18"
+version = "0.2.0-beta.19"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -525,6 +525,16 @@ fn build_stream_request_body(provider: &str, model: &str, messages: &[ChatMessag
                 body["thinking_budget"] = serde_json::json!(8000);
             }
 
+            // 本地 OpenAI 兼容服务：思考开关关闭时，显式发送 reasoning_effort=none
+            // 关闭思考。此前这个开关对 local 是摆设——qwen3.5 这类默认思考的模型
+            // 在 LM Studio 上每条消息都要先想几百上千个 token 才吐正文（实测
+            // chat_template_kwargs 和 /no_think 都关不掉，只有 reasoning_effort
+            // 有效）。范围只限自托管服务：Ollama 等不认识该字段的会静默忽略；
+            // 不发给远端商业 provider（Mistral 等严格实现会拒收未知字段）。
+            if !enable_thinking && matches!(provider, "local" | "custom" | "openclaw") {
+                body["reasoning_effort"] = serde_json::json!("none");
+            }
+
             // 如果有可用工具就加进去
             if !tools.is_empty() {
                 let tools_json: Vec<_> = tools
@@ -2114,6 +2124,24 @@ pub async fn run_turn(
                 return Ok(TurnOutcome::ToolCalls(calls));
             }
             let text = message.get("content").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            // 思考型模型（DeepSeek 系 reasoning_content / Ollama reasoning）可能
+            // content 留空、全部输出都在思考字段里。把这种情况在日志里点名——
+            // 调用方（Workspace 唤醒循环）会把空文本视为"未交卷"转入强制收尾，
+            // 但没有这行日志，排查时只能看到一次莫名其妙的空回复。
+            if text.trim().is_empty() {
+                let reasoning_len = message
+                    .get("reasoning_content")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| message.get("reasoning").and_then(|v| v.as_str()))
+                    .map(|s| s.len())
+                    .unwrap_or(0);
+                if reasoning_len > 0 {
+                    log::warn!(
+                        "[LLM] run_turn 返回空 content，但携带 {} 字符的 reasoning——思考型模型把输出埋进了思考字段",
+                        reasoning_len
+                    );
+                }
+            }
             Ok(TurnOutcome::Text(text))
         }
     }
@@ -2246,6 +2274,11 @@ fn build_run_turn_body(
             if enable_thinking && provider == "siliconflow" {
                 b["enable_thinking"] = serde_json::json!(true);
                 b["thinking_budget"] = serde_json::json!(8000);
+            }
+            // 与流式路径同款：本地服务在思考开关关闭时显式关掉思考，
+            // Workspace Agent 也能享受到（不开思考的 Agent 不再白等思考）
+            if !enable_thinking && matches!(provider, "local" | "custom" | "openclaw") {
+                b["reasoning_effort"] = serde_json::json!("none");
             }
             if !tools.is_empty() {
                 let tools_json: Vec<_> = tools
@@ -2524,6 +2557,35 @@ mod provider_tool_calling_tests {
             r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}"#,
         );
         assert!(matches!(parsed, Some(StreamContent::Thinking(ref s)) if s == "Let me think"));
+    }
+
+    #[test]
+    fn local_providers_get_reasoning_effort_none_only_when_thinking_disabled() {
+        let messages = vec![ChatMessage {
+            id: "1".into(), role: "user".into(), content: "hi".into(),
+            timestamp: 0, error: None, images: vec![], videos: vec![],
+        }];
+
+        // 本地服务 + 思考关闭：显式关思考（LM Studio 上 qwen3.5 这类默认思考
+        // 的模型只有 reasoning_effort 能关掉，chat_template_kwargs 和 /no_think
+        // 实测均无效）
+        let body = build_stream_request_body("local", "qwen3.5-9b", &messages, &[], false, None);
+        assert_eq!(body["reasoning_effort"], "none");
+
+        // 本地服务 + 思考开启：不干预，让模型按默认思考
+        let body = build_stream_request_body("local", "qwen3.5-9b", &messages, &[], true, None);
+        assert!(body.get("reasoning_effort").is_none());
+
+        // 远端商业 provider 一律不发该字段（Mistral 等严格实现会拒收未知字段）
+        let body = build_stream_request_body("openai", "gpt-4o", &messages, &[], false, None);
+        assert!(body.get("reasoning_effort").is_none());
+
+        // Workspace Agent 的非流式路径同款
+        let native = build_native_messages("local", &messages);
+        let body = build_run_turn_body("local", "qwen3.5-9b", None, &native, &[], None, false);
+        assert_eq!(body["reasoning_effort"], "none");
+        let body = build_run_turn_body("local", "qwen3.5-9b", None, &native, &[], None, true);
+        assert!(body.get("reasoning_effort").is_none());
     }
 
     fn image_message() -> ChatMessage {

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -1136,14 +1136,24 @@ async fn process_agent_wake(
 
         match outcome {
             TurnOutcome::Text(text) => {
+                // 空文本不算交卷：思考型模型（qwen3.5 经 Ollama 等）可能把整轮
+                // 输出都写进 reasoning 字段、content 为空。此前这里照样标记
+                // produced_final_text 并收工，表现为"Agent 明明跑了，工作区却
+                // 一条消息都没有"的静默失败。现在改为跳出循环但不标记完成，
+                // 交给下面的无工具强制收尾轮再逼一次真答案。
+                if text.trim().is_empty() {
+                    log::warn!(
+                        "[workspace] Agent「{}」返回空文本回复（疑似思考型模型把输出埋进 reasoning 字段），转入强制收尾轮",
+                        agent.name
+                    );
+                    break;
+                }
                 log::info!(
                     "[workspace] Agent「{}」产出最终回复 ({} 字符)",
                     agent.name, text.len()
                 );
                 append_text_reply(&agent.provider, &mut native_messages, &text);
-                if !text.trim().is_empty() {
-                    send_workspace_message(app_handle, workspace_id, agent_id, "user", &text).await;
-                }
+                send_workspace_message(app_handle, workspace_id, agent_id, "user", &text).await;
                 produced_final_text = true;
                 break;
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.18",
+  "version": "0.2.0-beta.19",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 一、限制盘点 #10：空文本不再算交卷

Workspace 唤醒循环里，`TurnOutcome::Text("")` 此前照样标记"已交卷"并收工——思考型模型把整轮输出埋进 `reasoning` 字段时，表现为"Agent 明明跑了，工作区一条消息都没有"的静默失败（昨日实测两次自然复现）。现改为：空文本转入无工具强制收尾轮再逼一次真答案；`run_turn` 在 content 空但携带 reasoning 时打 warn 日志，让这类失败在日志里现形。

改动为纯防御性：最坏情况与修复前等价（多一轮收尾尝试 + 诊断日志）。触发条件随机，本轮两次诱发尝试均正常交卷未触发；其导向的强制收尾路径已被 #82 的多轮真机验证（含日报助手生产案例）覆盖。

## 二、用户报障：LM Studio「每次问答 TTFT 超级高」根治

**排查结论链**（LM Studio 服务端日志 + 请求实验）：

1. 服务端处理飞快（prompt 预处理 100-270ms）——慢不在 LM Studio 本身；
2. qwen3.5-9b 默认思考，一个"1+1"产生 **1435 个 `reasoning_content` 思考块**；用户在 LM Studio 界面关闭的思考只对其自家聊天页生效，API 调用不受影响；
3. 旧版应用（beta.15）把思考流全部丢弃 → 用户等的是"模型想完后的首个正文 token"——这层 #81 已修（思考实时进折叠区）；
4. **本 PR 修的一层**：应用的"思考模式"开关对 local provider 是摆设（代码只对 siliconflow 生效）。实测 `chat_template_kwargs` 与 `/no_think` 均无法关闭 LM Studio 上的思考，**仅 `reasoning_effort: "none"` 有效**。现在思考开关关闭时，对 local/custom/openclaw 显式发送该字段（不识别的自托管服务如 Ollama 静默忽略；不发给远端商业 provider，严格实现会拒收未知字段）。流式聊天与 Workspace 非流式路径同步生效。

## 验证

- `cargo test` 46 项全过（新增 reasoning_effort 三向断言：local+关→有、local+开→无、远端→无）；`pnpm build` / `pnpm tauri build` 通过。
- 真机（release + LM Studio + qwen3.5-9b）：
  - 思考关（默认）：**正文 2 秒首现，思考区 0 字符**（beta.15 上同场景为十几秒以上空白）；
  - 思考开：思考区 **1 秒**开始实时滚动，正文随后；
  - 测试会话与临时配置已清理复原。

版本号 `0.2.0-beta.18` → `0.2.0-beta.19`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)