### PR TITLE
fix: 启动时自动更新检测默认改查 Beta 通道

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
-    "website:dev": "vite website",
-    "website:build": "vite build website --outDir dist",
-    "website:preview": "vite preview website --outDir dist",
-    "website:deploy": "wrangler deploy --config website/wrangler.jsonc",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
@@ -53,7 +49,6 @@
     "sass": "^1.72.0",
     "typescript": "^5.4.2",
     "vite": "^5.2.0",
-    "wrangler": "4.88.0",
     "vue-tsc": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.20",
+  "version": "0.2.0-beta.21",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
+    "website:dev": "vite website",
+    "website:build": "vite build website --outDir dist",
+    "website:preview": "vite preview website --outDir dist",
+    "website:deploy": "wrangler deploy --config website/wrangler.jsonc",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
@@ -49,6 +53,7 @@
     "sass": "^1.72.0",
     "typescript": "^5.4.2",
     "vite": "^5.2.0",
+    "wrangler": "4.88.0",
     "vue-tsc": "^2.0.6"
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.20"
+version = "0.2.0-beta.21"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/src/commands/app_update.rs
+++ b/src-tauri/src/commands/app_update.rs
@@ -4,14 +4,22 @@
 
 //! 设置页"检测最新版本"按钮用：查询 GitHub Releases，分别找出最新正式版
 //! 和最新 Beta 版，连同各自 Release 页面上的更新说明一起返回给前端展示。
-//! 这是纯信息查询，不涉及下载/安装（正式版安装走 tauri-plugin-updater 默认的
-//! updater-manifest 端点，由前端直接调用插件的 `check()`），因此直接用总超时
-//! 即可，不需要读间隔超时。
+//! 这是纯信息查询，不涉及下载/安装（安装走 tauri-plugin-updater 默认的
+//! endpoint，由前端直接调用插件的 `check()`），因此直接用总超时即可，不需要
+//! 读间隔超时。
 //!
-//! Beta 版安装走本文件下方的 `check_and_install_beta_update`：tauri-plugin-
-//! updater 的 JS `check()` 不支持运行时覆盖 endpoint（只认 tauri.conf.json
-//! 里的静态配置，那个配置对应稳定版清单），所以 Beta 安装改在 Rust 侧用
-//! `UpdaterBuilder::endpoints()` 显式指向 `updater-manifest-beta` 清单。
+//! tauri.conf.json 里的默认 endpoint 现指向 `updater-manifest-beta`（项目还
+//! 没有真正的正式版之前，`updater-manifest` 那条"仅正式版"通道会因为所有
+//! 发布都带 `-beta.N` 后缀被判定为 prerelease 而永远没有更新，见
+//! `.github/workflows/release.yml` 的 `prerelease` 判定逻辑）。等项目发布
+//! 真正的非预发布版本后，再把默认 endpoint 切回 `updater-manifest`。
+//!
+//! 本文件下方的 `check_and_install_beta_update` 是设置页"立即更新并安装
+//! Beta"按钮专用：tauri-plugin-updater 的 JS `check()` 不支持运行时覆盖
+//! endpoint（只认 tauri.conf.json 里的静态配置），所以这里在 Rust 侧用
+//! `UpdaterBuilder::endpoints()` 显式指向 `updater-manifest-beta` 清单——
+//! 即便默认 endpoint 现在也指向同一个清单，这个显式指定仍然保留，不依赖
+//! 默认配置将来切回正式版通道后这个按钮还能正常工作。
 
 use std::time::Duration;
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.20",
+  "version": "0.2.0-beta.21",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",
@@ -50,7 +50,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVENUI3RkQ3MjAwQjQ4MkEKUldRcVNBc2cxMzliWFRpYVYwUU85UHpWNFV4OTJHd29uTUptMjRRak9Eam1TYkNLTWpsM1E4SHkK",
       "endpoints": [
-        "https://github.com/baiyuheniao/BaiyuAISpace2/releases/download/updater-manifest/latest.json"
+        "https://github.com/baiyuheniao/BaiyuAISpace2/releases/download/updater-manifest-beta/latest.json"
       ],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
## 背景

用户反馈自用的 BaiyuAISpace（beta.14）启动时自动更新检测已经不弹提示了。

## 根因

- `.github/workflows/release.yml:75`：`prerelease: ${{ contains(github.ref_name, '-') }}`——凡是标签名带 `-` 的发布都会被标记为 prerelease。本项目所有版本号都是 `v0.2.0-beta.N` 格式，必然带 `-`，所以每次发布都被标记为 prerelease。
- `.github/workflows/publish-update-manifest.yml`：只有 `is_prerelease == false` 时才会把 `latest.json` 同步到"正式版"通道（`updater-manifest`，也是 `tauri.conf.json` 默认 endpoint、启动时自动检测用的那条）。
- 实测 `updater-manifest` 冻结在 `0.2.0-beta.12`（2026-07-14 发布，猜测是当时手动在 GitHub 网页上取消了 pre-release 勾选），之后 beta.13~beta.21 都没能再更新这条通道——项目现阶段还没有真正的"正式版"，这个通道从设计上就追不上纯 beta 发布节奏。
- 设置页手动"检测更新"不受影响：`check_latest_releases` 直接查 GitHub API 的真实 release 列表，不经过这条冻结的通道。

## 改动

- `src-tauri/tauri.conf.json`：默认 updater endpoint 从 `updater-manifest` 改为 `updater-manifest-beta`（这条通道每次发布，不管 beta 还是正式版，都会更新，见 `publish-update-manifest.yml`）。实测该通道当前已同步到 `0.2.0-beta.15`（含 `windows-x86_64` 平台），健康可用。
- `src-tauri/src/commands/app_update.rs`：更新模块顶部文档注释，说明默认 endpoint 现指向 Beta 通道及原因；标注等项目发布真正的非预发布版本后需要把默认 endpoint 切回 `updater-manifest`。
- 版本号按约定三处一致升至 `0.2.0-beta.21`（`package.json` / `src-tauri/tauri.conf.json` / `src-tauri/Cargo.toml`）——这个改动本身要靠一次新发布才能让已安装的旧版本用户实际吃到。

## 验证

- `cargo build`：通过，无警告，版本号确认为 beta.21。
- `pnpm build`：通过。
- `pnpm tauri build`：通过，产物 exe / NSIS 安装包正常生成，版本号为 `BaiyuAISpace_0.2.0-beta.21_x64-setup.exe`（结尾 updater 签名报错是本机没有 `TAURI_SIGNING_PRIVATE_KEY` 的已知良性失败）。

## 合并后还需要做的事

这个修复本身要等**这个版本被打 tag 并手动发布**之后，已安装旧版本的用户才能通过自动更新吃到——这也是这条 PR 里顺带把版本号升到 beta.21 的原因。合并后请记得走一遍发布流程（打 tag → 推送 → 去 Releases 页面检查草稿并手动发布）。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01C1LALeS4JLzWNxr4YMT9hB
