### PR TITLE
fix: 协作团队页面日志/对话/Agent列表容器滚动失效

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.21",
+  "version": "0.2.0-beta.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.21"
+version = "0.2.0-beta.22"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.21",
+  "version": "0.2.0-beta.22",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",

--- a/src/views/AgentTeamView.vue
+++ b/src/views/AgentTeamView.vue
@@ -2080,8 +2080,9 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
 
-  :deep(.n-card__content) {
+  :deep(.n-card-content) {
     flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -2144,6 +2145,8 @@ onBeforeUnmount(() => {
 }
 
 .agent-list {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -2153,6 +2156,7 @@ onBeforeUnmount(() => {
 
 .message-scroll {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   margin-bottom: 12px;
 }
@@ -2176,6 +2180,7 @@ onBeforeUnmount(() => {
 
 .timeline-scroll {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
## 问题

协作团队页面里，Agent 列表、对话消息、活动时间线（日志）三块内容一多就会把整个卡片撑高，一直延伸到屏幕很下面，而不是在固定高度的框内滚动。

## 根因

`AgentTeamView.vue` 中限高样式的选择器写成了 `.n-card__content`（双下划线），但 naive-ui 实际渲染的类名是 `.n-card-content`（单短横线），选择器从未匹配上，限高/flex 布局从未生效。另外 flex 子项默认 `min-height: auto`，即便 `flex: 1` 也不会主动收缩到比内容小，需要显式 `min-height: 0` 才能让 `overflow-y: auto` 真正触发滚动。

## 修复

- `.n-card__content` → `.n-card-content`
- 给限高容器（卡片内容区、`.message-scroll`、`.timeline-scroll`、`.agent-list`）加上 `min-height: 0`

## 验证

用 CDP driver 起调试实例实测：改前容器高度等于内容高度（无裁剪，如活动时间线内容曾达 20000+ px）；改后容器稳定在约 350px、可正常滚动，截图确认对话框/活动时间线均出现滚动条。`pnpm build`、`cargo build` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
