### PR TITLE
feat: 聊天页支持编辑消息/重新生成，历史记录页支持导出对话

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.22",
+  "version": "0.2.0-beta.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.22"
+version = "0.2.0-beta.23"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -311,9 +311,25 @@ impl Database {
     }
 
     /**
+     * 删除单条消息
+     * 用于消息编辑（截断编辑点之后的旧消息）和重新生成（删除待重生成的回复）
+     *
+     * @param message_id: 要删除的消息 ID
+     */
+    pub fn delete_message(&self, message_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+        self.conn.execute(
+            "DELETE FROM messages WHERE id = ?1",
+            [message_id],
+        )?;
+
+        log::info!("Message deleted: {}", message_id);
+        Ok(())
+    }
+
+    /**
      * 获取指定会话的所有消息
      * 按时间戳升序排列
-     * 
+     *
      * @param session_id: 会话 ID
      * @return 消息列表
      */

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -205,6 +205,8 @@ fn main() {
             save_message_cmd,
             get_sessions_cmd,
             delete_session_cmd,
+            delete_message_cmd,
+            export_text_file_cmd,
             clear_database_cmd,
             // 安全存储相关命令
             save_api_key,
@@ -572,6 +574,23 @@ async fn delete_session_cmd(
 ) -> Result<(), String> {
     let db = db_state.0.lock().await;
     db.delete_session(&session_id).map_err(|e| commands::local_model::friendly_err("删除会话失败，请重试", e))
+}
+
+#[tauri::command]
+async fn delete_message_cmd(
+    message_id: String,
+    db_state: tauri::State<'_, DbState>,
+) -> Result<(), String> {
+    let db = db_state.0.lock().await;
+    db.delete_message(&message_id).map_err(|e| commands::local_model::friendly_err("删除消息失败，请重试", e))
+}
+
+/// 导出对话为文本文件（JSON/TXT）：前端已用 save() 对话框拿到用户选择的落盘路径，
+/// 这里只负责把拼好的文本写进去。跟 copy_log_file 一样直接用 std::fs，不引入
+/// tauri-plugin-fs——避免为这一个功能新增插件依赖和权限声明。
+#[tauri::command]
+fn export_text_file_cmd(file_path: String, content: String) -> Result<(), String> {
+    std::fs::write(&file_path, content).map_err(|e| format!("导出失败: {}", e))
 }
 
 /// 清空数据库：删除全部会话、消息、MCP 服务器配置、Skill（设置页“危险操作”按钮对应的后端命令）

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.22",
+  "version": "0.2.0-beta.23",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -28,6 +28,10 @@ import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from "vue"
 // 导入 NaiveUI 组件
 import { NAvatar, NIcon, NSpin, NAlert, NTooltip } from "naive-ui";
 
+// 聊天 Store - 编辑/重新生成都要落库并重新发起生成请求，这两件事和消息本身
+// 的截断/删除逻辑都在 store 里，组件只负责触发
+import { useChatStore } from "@/stores/chat";
+
 // Markdown 渲染管线。marked/KaTeX/DOMPurify/hljs/Mermaid 的全局配置都在该
 // 模块顶层完成，整个应用只执行一次——不能放回本组件的 <script setup>：
 // setup 顶层语句每挂载一条消息都会重新执行，会给全局单例反复叠加扩展/钩子，
@@ -38,13 +42,15 @@ import { renderMarkdown, renderMermaidDiagrams } from "@/utils/markdown";
 import type { Message } from "@/stores/chat";
 
 // 导入图标
-import { Person, Sparkles, Copy } from "@vicons/ionicons5";
+import { Person, Sparkles, Copy, Create, Refresh, Checkmark, Close } from "@vicons/ionicons5";
 
 // ============ Props 定义 ============
 
 const props = defineProps<{
   message: Message;
 }>();
+
+const chat = useChatStore();
 
 // ref 指向渲染 markdown 的 DOM 节点，用于查找 Mermaid 占位元素
 const contentRef = ref<HTMLElement | null>(null);
@@ -160,6 +166,61 @@ const handleCopy = async () => {
     console.error("Failed to copy:", err);
   }
 };
+
+// ============ 编辑用户消息 ============
+
+// 是否处于编辑态；编辑框草稿内容
+const isEditing = ref(false);
+const editDraft = ref("");
+const editTextareaRef = ref<HTMLTextAreaElement | null>(null);
+
+// 编辑框随内容自动长高，避免长消息挤成一小格滚动条
+const autoGrowEditTextarea = () => {
+  const el = editTextareaRef.value;
+  if (!el) return;
+  el.style.height = "auto";
+  el.style.height = `${el.scrollHeight}px`;
+};
+
+const startEdit = async () => {
+  editDraft.value = props.message.content;
+  isEditing.value = true;
+  await nextTick();
+  autoGrowEditTextarea();
+  editTextareaRef.value?.focus();
+};
+
+const cancelEdit = () => {
+  isEditing.value = false;
+  editDraft.value = "";
+};
+
+// 保存编辑：截断该消息之后的旧回复分支，重新请求一次生成
+const confirmEdit = async () => {
+  if (!editDraft.value.trim() || chat.isLoading) return;
+  const content = editDraft.value;
+  isEditing.value = false;
+  editDraft.value = "";
+  await chat.editUserMessage(props.message.id, content);
+};
+
+// Enter 保存，Shift+Enter 换行，Esc 取消——跟 ChatInput 的发送框键位保持一致
+const handleEditKeydown = (e: KeyboardEvent) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    confirmEdit();
+  } else if (e.key === "Escape") {
+    e.preventDefault();
+    cancelEdit();
+  }
+};
+
+// ============ 重新生成 AI 回复 ============
+
+const handleRegenerate = async () => {
+  if (chat.isLoading) return;
+  await chat.regenerateMessage(props.message.id);
+};
 </script>
 
 <template>
@@ -217,13 +278,50 @@ const handleCopy = async () => {
           >
         </div>
 
+        <!-- 编辑态：用户消息点"编辑"后把正文换成文本框 -->
         <div
+          v-if="isEditing"
+          class="message-edit"
+        >
+          <textarea
+            ref="editTextareaRef"
+            v-model="editDraft"
+            class="edit-textarea"
+            placeholder="编辑消息内容..."
+            @input="autoGrowEditTextarea"
+            @keydown="handleEditKeydown"
+          />
+          <div class="edit-actions">
+            <button
+              class="edit-btn edit-btn-primary"
+              :disabled="!editDraft.trim() || chat.isLoading"
+              @click="confirmEdit"
+            >
+              <n-icon :size="14">
+                <Checkmark />
+              </n-icon>
+              保存并重新生成
+            </button>
+            <button
+              class="edit-btn"
+              @click="cancelEdit"
+            >
+              <n-icon :size="14">
+                <Close />
+              </n-icon>
+              取消
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-else
           ref="contentRef"
           class="markdown-content"
           @click="handleMarkdownClick"
           v-html="renderedContent"
         />
-        
+
         <!-- Streaming indicator -->
         <div
           v-if="message.streaming"
@@ -280,9 +378,30 @@ const handleCopy = async () => {
 
       <!-- Actions -->
       <div
-        v-if="!isUser && !message.streaming"
+        v-if="!message.streaming && !isEditing"
         class="message-actions"
       >
+        <button
+          v-if="isUser"
+          class="action-btn"
+          title="编辑"
+          @click="startEdit"
+        >
+          <n-icon :size="14">
+            <Create />
+          </n-icon>
+        </button>
+        <button
+          v-if="isAssistant"
+          class="action-btn"
+          title="重新生成"
+          :disabled="chat.isLoading"
+          @click="handleRegenerate"
+        >
+          <n-icon :size="14">
+            <Refresh />
+          </n-icon>
+        </button>
         <n-tooltip
           placement="top"
           :show="copied"
@@ -673,6 +792,76 @@ const handleCopy = async () => {
   word-break: break-word;
 }
 
+/* 编辑态：用户消息就地改成文本框 */
+.message-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.edit-textarea {
+  width: 100%;
+  min-height: 60px;
+  padding: 10px 12px;
+  background: $bg;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  color: $ink;
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: $leading-body;
+  resize: none;
+  overflow: hidden;
+  transition: border-color $duration $ease;
+
+  &:focus {
+    outline: none;
+    border-color: $ink;
+  }
+}
+
+.edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.edit-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
+  background: $bg;
+  color: $ink-soft;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition:
+    background $duration $ease,
+    color $duration $ease;
+
+  &:hover:not(:disabled) {
+    background: $ink;
+    color: $bg;
+  }
+
+  &:disabled {
+    color: $ink-faint;
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
+.edit-btn-primary {
+  background: $ink;
+  border-color: $ink;
+  color: $bg;
+
+  &:hover:not(:disabled) {
+    background: $bg;
+    color: $ink;
+  }
+}
+
 .streaming-indicator {
   display: flex;
   align-items: center;
@@ -768,6 +957,17 @@ const handleCopy = async () => {
   transition:
     background $duration $ease,
     color $duration $ease;
+
+  &:disabled {
+    color: $ink-faint;
+    cursor: not-allowed;
+    opacity: 0.5;
+
+    &:hover {
+      background: $bg;
+      color: $ink-faint;
+    }
+  }
 }
 
 .streaming-text {

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -501,37 +501,27 @@ export const useChatStore = defineStore("chat", () => {
   };
 
   /**
-   * 发送消息 (核心函数)
-   * 处理用户消息发送、LLM 调用、流式响应等完整流程
+   * 校验当前会话可用于生成回复的 API 配置
+   * sendMessage / regenerateMessage / editUserMessage 共用同一份校验逻辑
    *
-   * @param content - 消息内容
-   * @param attachedFiles - 附件文件列表 (可选, 仅元数据)
-   * @param images - 图片附件 (可选, 含 base64 数据)
-   * @returns void
+   * @returns 校验通过的配置对象，失败返回 null（已弹出 alert 提示）
    */
-  const sendMessage = async (
-    content: string,
-    attachedFiles?: Array<{ name: string; size: number }>,
-    images?: ImageAttachment[],
-    videos?: VideoAttachment[],
-    documentContents?: Array<{ name: string; content: string }>
-  ) => {
-    // 检查是否有当前会话
-    if (!currentSession.value) return;
+  const resolveActiveConfig = () => {
+    if (!currentSession.value) return null;
 
     // 优先使用当前激活的 API 配置（允许在不新建会话的情况下切换 API）
-    const effectiveConfigId = settings.activeConfigId ?? currentSession.value!.apiConfigId;
+    const effectiveConfigId = settings.activeConfigId ?? currentSession.value.apiConfigId;
     const config = settings.apiConfigs.find(c => c.id === effectiveConfigId);
     if (!config) {
       console.error("API config not found for session");
       alert("未找到 API 配置，请检查设置");
-      return;
+      return null;
     }
     // 若与会话绑定的配置不同，同步更新当前会话（影响 History 显示）
-    if (effectiveConfigId !== currentSession.value!.apiConfigId) {
-      currentSession.value!.apiConfigId = config.id;
-      currentSession.value!.provider = config.provider;
-      currentSession.value!.model = config.model;
+    if (effectiveConfigId !== currentSession.value.apiConfigId) {
+      currentSession.value.apiConfigId = config.id;
+      currentSession.value.provider = config.provider;
+      currentSession.value.model = config.model;
     }
 
     // 检查 API 密钥是否已加载
@@ -539,63 +529,32 @@ export const useChatStore = defineStore("chat", () => {
     if (config.provider !== "local" && !config.apiKey) {
       console.error("API key not loaded for config:", config.id);
       alert("API 密钥未加载，请重启应用或重新设置");
-      return;
+      return null;
     }
 
-    // 初始化内容变量
-    let enhancedContent = content;
+    return config;
+  };
 
-    // ============ 文档上下文注入 ============
-    let docContext = "";
-    if (documentContents && documentContents.length > 0) {
-      const docParts = documentContents.map(d => `[文档: ${d.name}]\n${d.content}`);
-      docContext = `[用户附加文档]\n${docParts.join('\n---\n')}`;
-    }
+  /**
+   * 基于当前会话已有的消息列表向 LLM 请求一次新回复 (核心生成函数)
+   * 发送新消息、编辑用户消息后重新生成、点击"重新生成"共用这一段逻辑——
+   * 三者的差异只在调用前如何整理 currentSession.value.messages，生成本身
+   * (占位消息、构建 API 消息数组、system prompt 注入、流式调用、标题更新、
+   * 错误处理) 完全一致，不应该抄三份。
+   *
+   * @param contentOverride - 仅用于 sendMessage 的 RAG/文档上下文注入：某条
+   *   消息在聊天气泡里显示原始输入，但发给模型的那一份要换成注入过上下文的
+   *   增强内容。不传则每条消息都按 m.content 原样发送。
+   * @returns void
+   */
+  const generateReply = async (contentOverride?: { messageId: string; content: string }) => {
+    if (!currentSession.value) return;
 
-    // ============ RAG 检索增强 ============
-    let retrievalContext = "";
-    if (ragEnabled.value && selectedKnowledgeBaseId.value) {
-      const kb = kbStore.knowledgeBases.find(k => k.id === selectedKnowledgeBaseId.value);
-      if (kb) {
-        const result = await kbStore.searchKnowledgeBase(
-          selectedKnowledgeBaseId.value,
-          content
-        );
-        if (result && result.chunks.length > 0) {
-          lastRetrievalResult.value = result;
-          retrievalContext = buildRagContext(result);
-        }
-      }
-    }
+    const config = resolveActiveConfig();
+    if (!config) return;
 
-    // 合并上下文，构建最终发送内容
-    const contextParts: string[] = [];
-    if (retrievalContext) contextParts.push(retrievalContext);
-    if (docContext) contextParts.push(docContext);
-    if (contextParts.length > 0) {
-      enhancedContent = `${contextParts.join('\n\n')}\n\n问题：${content}`;
-    }
-
-    // 构建用户消息对象
-    const userMessage: Message = {
-      id: crypto.randomUUID(),
-      role: "user",
-      content,
-      timestamp: Date.now(),
-      files: attachedFiles && attachedFiles.length > 0 ? attachedFiles : undefined,
-      images: images && images.length > 0 ? images : undefined,
-      videos: videos && videos.length > 0 ? videos : undefined,
-    };
-
-    // 添加到当前会话
-    currentSession.value.messages.push(userMessage);
-    currentSession.value.updatedAt = Date.now();
     isLoading.value = true;
     currentStreamContent.value = "";
-
-    // 保存到数据库（先保存 session，再保存 message，满足外键约束）
-    await saveSessionToDb();
-    await saveMessageToDb(userMessage);
 
     try {
       // 创建助手消息占位
@@ -609,34 +568,18 @@ export const useChatStore = defineStore("chat", () => {
       currentSession.value.messages.push(assistantMessage);
 
       // ============ 构建 API 消息列表 ============
-      // Use userMessage.id to identify the RAG target — positional index is
-      // unreliable when prior error messages have been filtered out of the array.
       const apiMessages = currentSession.value.messages
         // 过滤掉流式中和有错误的消息
         .filter(m => !m.streaming && !m.error)
-        .map((m) => {
-          // 如果有增强内容（RAG 或文档注入），在当前用户消息中替换
-          if (m.id === userMessage.id && enhancedContent !== content) {
-            return {
-              id: m.id,
-              role: m.role,
-              content: enhancedContent,
-              timestamp: m.timestamp,
-              error: m.error,
-              images: m.images ?? [],
-              videos: m.videos ?? [],
-            };
-          }
-          return {
-            id: m.id,
-            role: m.role,
-            content: m.content,
-            timestamp: m.timestamp,
-            error: m.error,
-            images: m.images ?? [],
-            videos: m.videos ?? [],
-          };
-        });
+        .map((m) => ({
+          id: m.id,
+          role: m.role,
+          content: (contentOverride && m.id === contentOverride.messageId) ? contentOverride.content : m.content,
+          timestamp: m.timestamp,
+          error: m.error,
+          images: m.images ?? [],
+          videos: m.videos ?? [],
+        }));
 
       // ============ 全局 System Prompt ============
       const globalSystemPrompt = settings.systemPrompt.trim();
@@ -701,11 +644,11 @@ export const useChatStore = defineStore("chat", () => {
 
       // ============ 调用后端流式消息 API ============
       try {
-        console.log("[sendMessage] Calling stream_message, sessionId:", requestPayload.sessionId, "messageCount:", requestPayload.messages.length);
+        console.log("[generateReply] Calling stream_message, sessionId:", requestPayload.sessionId, "messageCount:", requestPayload.messages.length);
         await invoke('stream_message', { request: requestPayload });
-        console.log("[sendMessage] stream_message completed");
+        console.log("[generateReply] stream_message completed");
       } catch (e) {
-        console.error('[sendMessage] stream_message error:', e);
+        console.error('[generateReply] stream_message error:', e);
         if (import.meta.env.DEV) console.error('stream_message error', e);
         throw e;
       }
@@ -713,7 +656,8 @@ export const useChatStore = defineStore("chat", () => {
       // ============ 更新会话标题 ============
       // 如果是第一条对话 (用户消息 + 助手回复)，更新标题
       if (currentSession.value.messages.length === 2) {
-        currentSession.value.title = content.slice(0, 30) + (content.length > 30 ? "..." : "");
+        const firstUserMessage = currentSession.value.messages[0];
+        currentSession.value.title = firstUserMessage.content.slice(0, 30) + (firstUserMessage.content.length > 30 ? "..." : "");
         await saveSessionToDb();
         // 只局部更新 sessions 列表的标题，不调用 loadSessionsFromDb()
         // 原因：loadSessionsFromDb 会用 DB 旧数据覆盖内存中正在 streaming 的 assistantMessage，导致消息消失
@@ -740,18 +684,176 @@ export const useChatStore = defineStore("chat", () => {
       // ============ 错误处理 ============
       const errorInfo = classifyError(error);
       const lastMessage = currentSession.value.messages[currentSession.value.messages.length - 1];
-      
+
       // 将错误信息保存到消息中
       if (lastMessage.role === "assistant") {
         lastMessage.error = errorInfo.message;
         lastMessage.streaming = false;
         await saveMessageToDb(lastMessage);
       }
-      
+
       console.error(`[${errorInfo.type}] ${error}`);
       isLoading.value = false;
       currentStreamContent.value = "";
     }
+  };
+
+  /**
+   * 发送消息 (核心函数)
+   * 处理用户消息发送、LLM 调用、流式响应等完整流程
+   *
+   * @param content - 消息内容
+   * @param attachedFiles - 附件文件列表 (可选, 仅元数据)
+   * @param images - 图片附件 (可选, 含 base64 数据)
+   * @returns void
+   */
+  const sendMessage = async (
+    content: string,
+    attachedFiles?: Array<{ name: string; size: number }>,
+    images?: ImageAttachment[],
+    videos?: VideoAttachment[],
+    documentContents?: Array<{ name: string; content: string }>
+  ) => {
+    // 检查是否有当前会话
+    if (!currentSession.value) return;
+    if (!resolveActiveConfig()) return;
+
+    // 初始化内容变量
+    let enhancedContent = content;
+
+    // ============ 文档上下文注入 ============
+    let docContext = "";
+    if (documentContents && documentContents.length > 0) {
+      const docParts = documentContents.map(d => `[文档: ${d.name}]\n${d.content}`);
+      docContext = `[用户附加文档]\n${docParts.join('\n---\n')}`;
+    }
+
+    // ============ RAG 检索增强 ============
+    let retrievalContext = "";
+    if (ragEnabled.value && selectedKnowledgeBaseId.value) {
+      const kb = kbStore.knowledgeBases.find(k => k.id === selectedKnowledgeBaseId.value);
+      if (kb) {
+        const result = await kbStore.searchKnowledgeBase(
+          selectedKnowledgeBaseId.value,
+          content
+        );
+        if (result && result.chunks.length > 0) {
+          lastRetrievalResult.value = result;
+          retrievalContext = buildRagContext(result);
+        }
+      }
+    }
+
+    // 合并上下文，构建最终发送内容
+    const contextParts: string[] = [];
+    if (retrievalContext) contextParts.push(retrievalContext);
+    if (docContext) contextParts.push(docContext);
+    if (contextParts.length > 0) {
+      enhancedContent = `${contextParts.join('\n\n')}\n\n问题：${content}`;
+    }
+
+    // 构建用户消息对象——聊天气泡展示原始输入，RAG/文档增强内容只通过
+    // generateReply 的 contentOverride 参数注入发给模型的那份拷贝，不写进
+    // 消息本身（写进去用户编辑这条消息时会看到一堆检索上下文，体验很差）
+    const userMessage: Message = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content,
+      timestamp: Date.now(),
+      files: attachedFiles && attachedFiles.length > 0 ? attachedFiles : undefined,
+      images: images && images.length > 0 ? images : undefined,
+      videos: videos && videos.length > 0 ? videos : undefined,
+    };
+
+    // 添加到当前会话
+    currentSession.value.messages.push(userMessage);
+    currentSession.value.updatedAt = Date.now();
+
+    // 保存到数据库（先保存 session，再保存 message，满足外键约束）
+    await saveSessionToDb();
+    await saveMessageToDb(userMessage);
+
+    await generateReply(
+      enhancedContent !== content ? { messageId: userMessage.id, content: enhancedContent } : undefined
+    );
+  };
+
+  /**
+   * 从数据库批量删除消息（编辑/重新生成截断旧分支时用）
+   * 失败塞进 dbSaveErrorNotices 队列走统一弹窗，理由同 saveMessageToDb——
+   * store 里拿不到 NMessageProvider 上下文，没法直接弹窗
+   *
+   * @param messages - 要删除的消息列表
+   * @returns void
+   */
+  const deleteMessagesFromDb = async (messages: Message[]) => {
+    for (const m of messages) {
+      try {
+        await invoke("delete_message_cmd", { messageId: m.id });
+      } catch (error) {
+        console.error("Failed to delete message:", error);
+        dbSaveErrorNotices.value.push(`旧消息清理失败：${classifyError(error).message}`);
+      }
+    }
+  };
+
+  /**
+   * 编辑一条已发送的用户消息并重新生成回复
+   * 截断该消息之后的所有旧消息（含旧的 AI 回复），更新消息内容，再重新请求一次生成——
+   * 与 ChatGPT/Claude 官方客户端的"编辑并重新生成"行为一致，不支持只改文字不重新生成，
+   * 因为旧回复是针对旧内容生成的，留着会造成上下文和回复对不上。
+   *
+   * @param messageId - 要编辑的用户消息 ID
+   * @param newContent - 编辑后的新内容
+   * @returns void
+   */
+  const editUserMessage = async (messageId: string, newContent: string) => {
+    if (!currentSession.value) return;
+    if (isLoading.value) return;
+
+    const idx = currentSession.value.messages.findIndex(m => m.id === messageId);
+    if (idx === -1) return;
+    const target = currentSession.value.messages[idx];
+    if (target.role !== "user") return;
+
+    const trimmed = newContent.trim();
+    if (!trimmed) return;
+
+    // 截断该消息之后的所有消息（旧回复分支作废）
+    const removed = currentSession.value.messages.splice(idx + 1);
+
+    target.content = trimmed;
+    target.error = undefined;
+    currentSession.value.updatedAt = Date.now();
+
+    // 先删库里的旧消息，再保存编辑后的内容
+    await deleteMessagesFromDb(removed);
+    await saveMessageToDb(target);
+    await saveSessionToDb();
+
+    await generateReply();
+  };
+
+  /**
+   * 重新生成指定的 AI 回复
+   * 删除该回复（及其后的所有消息，理论上只会有它自己），基于剩余上下文重新请求一次生成
+   *
+   * @param messageId - 要重新生成的 assistant 消息 ID
+   * @returns void
+   */
+  const regenerateMessage = async (messageId: string) => {
+    if (!currentSession.value) return;
+    if (isLoading.value) return;
+
+    const idx = currentSession.value.messages.findIndex(m => m.id === messageId);
+    if (idx === -1) return;
+    const target = currentSession.value.messages[idx];
+    if (target.role !== "assistant") return;
+
+    const removed = currentSession.value.messages.splice(idx);
+    await deleteMessagesFromDb(removed);
+
+    await generateReply();
   };
 
   /**
@@ -893,6 +995,8 @@ export const useChatStore = defineStore("chat", () => {
     createSession,           // 创建新会话
     loadSession,             // 加载会话
     sendMessage,             // 发送消息
+    editUserMessage,         // 编辑用户消息并重新生成
+    regenerateMessage,       // 重新生成 AI 回复
     deleteSession,           // 删除会话
     clearSession,            // 清除当前会话
     toggleSkillActive,       // 切换 Skill 手动激活状态

--- a/src/utils/exportConversation.ts
+++ b/src/utils/exportConversation.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * 对话导出
+ * 把 ChatSession 转成用户可选的 JSON / TXT 文本，供 ChatView 落盘保存
+ */
+
+import type { ChatSession } from "@/stores/chat";
+
+export type ExportFormat = "json" | "txt";
+
+const formatTimestamp = (ts: number): string =>
+  new Date(ts).toLocaleString("zh-CN", { hour12: false });
+
+/** 文件名里不能出现的字符统一替换掉，避免不同平台的落盘校验各不相同 */
+const sanitizeFilename = (name: string): string =>
+  name.replace(/[\\/:*?"<>|]/g, "_").trim().slice(0, 40) || "对话";
+
+/**
+ * 构建导出内容
+ *
+ * @param session - 要导出的会话
+ * @param format - 目标格式，"json" 保留结构化字段，"txt" 是人类可读的对话记录
+ * @returns 文本内容 + 建议文件名（不含路径）
+ */
+export function buildConversationExport(
+  session: ChatSession,
+  format: ExportFormat
+): { content: string; filename: string } {
+  const dateStr = new Date(session.updatedAt).toISOString().slice(0, 10);
+  const baseName = `${sanitizeFilename(session.title)}_${dateStr}`;
+
+  // 流式中的占位消息不该出现在导出结果里
+  const messages = session.messages.filter((m) => !m.streaming);
+
+  if (format === "json") {
+    const payload = {
+      title: session.title,
+      provider: session.provider,
+      model: session.model,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      messages: messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+        timestamp: m.timestamp,
+        error: m.error,
+      })),
+    };
+    return {
+      content: JSON.stringify(payload, null, 2),
+      filename: `${baseName}.json`,
+    };
+  }
+
+  const roleLabel = (role: string) =>
+    role === "user" ? "你" : role === "assistant" ? "AI 助手" : "系统";
+
+  const lines: string[] = [
+    `对话标题：${session.title}`,
+    `模型：${session.provider} / ${session.model}`,
+    `创建时间：${formatTimestamp(session.createdAt)}`,
+    `更新时间：${formatTimestamp(session.updatedAt)}`,
+    "",
+    "====================",
+    "",
+  ];
+
+  for (const m of messages) {
+    lines.push(`[${formatTimestamp(m.timestamp)}] ${roleLabel(m.role)}：`);
+    lines.push(m.content || (m.error ? `（出错：${m.error}）` : "（空）"));
+    lines.push("");
+  }
+
+  return {
+    content: lines.join("\n"),
+    filename: `${baseName}.txt`,
+  };
+}

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -21,9 +21,12 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
-import { NEmpty, NList, NListItem, NThing, NTag, NText, NButton, NIcon, NSpin, NPopconfirm, NSpace } from "naive-ui";
+import { NEmpty, NList, NListItem, NThing, NTag, NText, NButton, NIcon, NSpin, NPopconfirm, NSpace, NDropdown, useMessage, type DropdownOption } from "naive-ui";
+import { save } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "@/stores/chat";
-import { ChatbubblesOutline, TrashOutline, EnterOutline } from "@vicons/ionicons5";
+import { buildConversationExport, type ExportFormat } from "@/utils/exportConversation";
+import { ChatbubblesOutline, TrashOutline, EnterOutline, DownloadOutline } from "@vicons/ionicons5";
 
 // ============ 路由和状态管理 ============
 
@@ -33,12 +36,47 @@ const router = useRouter();
 // 聊天 Store - 管理会话列表
 const chat = useChatStore();
 
+// 提示消息 - 导出结果反馈，统一走左下角弹窗
+const message = useMessage();
+
 // ============ 本地状态 ============
 
 /** 加载状态 - 显示加载动画 */
 const loading = ref(false);
 
 // ============ 方法函数 ============
+
+/** 导出格式下拉菜单选项 */
+const exportOptions: DropdownOption[] = [
+  { label: "导出为 JSON", key: "json" },
+  { label: "导出为 TXT", key: "txt" },
+];
+
+/**
+ * 导出指定会话
+ * 弹出系统保存对话框选择落盘位置，再调用后端命令写入文件内容
+ *
+ * @param session - 要导出的会话（历史列表里已带全量消息，不用再单独加载）
+ * @param format - 导出格式，"json" 或 "txt"
+ */
+const handleExport = async (session: typeof chat.sessions[0], format: ExportFormat) => {
+  try {
+    const { content, filename } = buildConversationExport(session, format);
+    const filePath = await save({
+      defaultPath: filename,
+      filters: [{
+        name: format === "json" ? "JSON 文件" : "文本文件",
+        extensions: [format],
+      }],
+    });
+    if (!filePath) return; // 用户取消了保存对话框
+
+    await invoke("export_text_file_cmd", { filePath, content });
+    message.success(`对话已导出到：${filePath}`);
+  } catch (error) {
+    message.error(`导出失败：${error}`);
+  }
+};
 
 /**
  * 加载会话列表
@@ -233,6 +271,25 @@ onMounted(() => {
                   >
                     {{ formatDate(session.updatedAt) }}
                   </n-text>
+                  <!-- 导出按钮 (悬停时显示) -->
+                  <n-dropdown
+                    trigger="click"
+                    :options="exportOptions"
+                    @select="(key: string) => handleExport(session, key as ExportFormat)"
+                  >
+                    <n-button
+                      quaternary
+                      circle
+                      size="small"
+                      class="export-btn"
+                      title="导出对话"
+                      @click.stop
+                    >
+                      <template #icon>
+                        <n-icon><DownloadOutline /></n-icon>
+                      </template>
+                    </n-button>
+                  </n-dropdown>
                   <!-- 删除按钮 (悬停时显示) -->
                   <n-popconfirm
                     positive-text="删除"
@@ -402,13 +459,15 @@ onMounted(() => {
   white-space: nowrap;
 }
 
-/* 删除按钮 - 默认隐藏 */
+/* 导出/删除按钮 - 默认隐藏 */
+.export-btn,
 .delete-btn {
   opacity: 0;
   transition: opacity 0.2s;
 }
 
-/* 悬停时显示删除按钮 */
+/* 悬停时显示导出/删除按钮 */
+.history-item:hover .export-btn,
 .history-item:hover .delete-btn {
   opacity: 1;
 }


### PR DESCRIPTION
## 变更内容

- **编辑消息**：用户消息悬浮出现"编辑"按钮，点击后正文原地换成文本框（Enter 保存 / Shift+Enter 换行 / Esc 取消）。保存后会截断该消息之后的所有旧消息（含旧回复），把编辑后的内容重新发给模型生成新回复——对齐 ChatGPT/Claude 官方客户端的标准行为。
- **重新生成**：AI 回复悬浮出现"重新生成"按钮，删除该回复后基于之前的上下文重新请求一次。
- **导出对话**：历史记录页每条会话新增导出按钮，下拉选择"导出为 JSON / 导出为 TXT"，走系统保存对话框选择路径落盘。JSON 保留结构化字段（角色/内容/时间戳），TXT 是人类可读的对话记录。

## 实现说明

- 后端新增两个命令：`delete_message_cmd`（编辑/重新生成截断旧消息用）、`export_text_file_cmd`（写导出文件，复用 `copy_log_file` 的 `std::fs` 直写模式，没有新增 `tauri-plugin-fs` 依赖）。
- 前端把原来 `sendMessage` 里"占位消息 + 构建请求 + 流式调用 + 标题更新 + 错误处理"这段逻辑抽成公共的 `generateReply()`，编辑、重新生成、正常发送三条路径共用，没有抄三份。
- 版本号升至 `0.2.0-beta.23`。

## 测试情况

- `pnpm build`（vue-tsc + vite build）、`cargo build`、`pnpm tauri build` 三项编译门禁全过（`pnpm tauri build` 最后一步的更新签名失败是因为本机没配 `TAURI_SIGNING_PRIVATE_KEY`，跟这次改动无关，编译和打包本身成功）。
- 用 `run-baiyuaispace2` driver 在真实窗口里跑了一遍：发消息 → 编辑 → 保存重新生成 → 点重新生成，全程截图确认 UI 和数据流都对，没有出现重复消息或残留旧回复；历史记录页的导出下拉菜单样式也截图确认过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNTkFmXroh4DCdLPAdWyYp