### PR TITLE
fix: workspace_message 兜底按名字解析 Agent，避免 to_agent_id 填错静默丢消息

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.24",
+  "version": "0.2.0-beta.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.24"
+version = "0.2.0-beta.25"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -1749,12 +1749,12 @@ fn workspace_tool_defs(agent: &WorkspaceAgent) -> Vec<MCPTool> {
             server_id: "workspace".to_string(),
             server_name: "workspace".to_string(),
             name: "workspace_message".to_string(),
-            description: "向工作组内的其他 Agent 或用户发送一条消息。to_agent_id 填具体 Agent 的 id，或填 \"all\" 广播给所有人。"
+            description: "向工作组内的其他 Agent 或用户发送一条消息。to_agent_id 填具体 Agent 的 id（推荐，用 workspace_agent_list 获取），也可以直接填它的名字；或填 \"all\" 广播给所有人。"
                 .to_string(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "to_agent_id": { "type": "string", "description": "目标 Agent 的 id，或 \"all\" 广播给所有人" },
+                    "to_agent_id": { "type": "string", "description": "目标 Agent 的 id 或名字，或 \"all\" 广播给所有人" },
                     "content": { "type": "string", "description": "消息内容" }
                 },
                 "required": ["to_agent_id", "content"]
@@ -1965,11 +1965,33 @@ async fn dispatch_tool_call(
 ) -> serde_json::Value {
     match call.name.as_str() {
         "workspace_message" => {
-            let to_agent_id = call.arguments.get("to_agent_id").and_then(|v| v.as_str()).unwrap_or("all").to_string();
+            let raw_to = call.arguments.get("to_agent_id").and_then(|v| v.as_str()).unwrap_or("all").to_string();
             let content = call.arguments.get("content").and_then(|v| v.as_str()).unwrap_or("").to_string();
             if content.trim().is_empty() {
                 return serde_json::json!({ "error": "content 不能为空" });
             }
+            // 模型经常记不住创建时拿到的 UUID，只记得自己给 Agent 起的名字，
+            // 于是拿名字当 id 传进来——如果不在这里兜底解析，消息会带着一个
+            // 谁都不认的 to_agent_id 静默落库：唤醒查不到 handle、历史回放也
+            // 按真实 id 过滤不出这条消息，目标 Agent 永远收不到，模型却拿到
+            // 一个 "sent" 的假成功，会一直误以为对方在处理。
+            let to_agent_id = if raw_to == "all" {
+                raw_to
+            } else {
+                let members = list_agents_for_workspace(app_handle, &workspace.id).await;
+                if members.iter().any(|a| a.id == raw_to) {
+                    raw_to
+                } else if let Some(matched) = members.iter().find(|a| a.name == raw_to) {
+                    matched.id.clone()
+                } else {
+                    return serde_json::json!({
+                        "error": format!(
+                            "找不到 id 或名字为「{}」的 Agent，请先调用 workspace_agent_list 确认目标 Agent 的真实 id",
+                            raw_to
+                        )
+                    });
+                }
+            };
             if to_agent_id == agent.id {
                 return serde_json::json!({ "error": "不能给自己发消息，请使用 workspace_agent_list 查看其他 Agent 的 id" });
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.24",
+  "version": "0.2.0-beta.25",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 问题

实测 Agent Team 时发现：主 Agent（Leader）创建子 Agent 后，只记得自己给它起的名字（如"选题策划-小策"），记不住真实 UUID，调用 `workspace_message` 时直接拿名字当 `to_agent_id` 传了进去。

`workspace_message` 工具原来对 `to_agent_id` 完全不校验，消息照常落库、还回一句 `{"status": "sent"}` 骗过模型说"发成功了"。但实际唤醒逻辑是拿这个 id 去一个以真实 UUID 为 key 的 HashMap 里查 handle——查不到，唤醒静默失败；子 Agent 自己重建历史时也是严格按真实 id 过滤，这条消息连它自己都看不到。结果：目标 Agent 一直空闲、对话历史彻底为空，Leader 却一直以为对方在处理任务。

日志实锤（本机 `app_2026-07-21.log`）：
```
消息路由: user → e711699c-af7e-... （真实 UUID，正常）
消息路由: e711699c-af7e-... → 选题策划-小策 （名字，不是 UUID，问题所在）
```

## 修复

在 `dispatch_tool_call` 的 `workspace_message` 分支加一层解析：
1. `to_agent_id` 先按真实 id 精确匹配工作组成员；
2. 匹配不到，退化按 Agent 名字精确匹配，命中则解析为真实 id；
3. 两者都匹配不到，直接返回错误提示模型去调用 `workspace_agent_list` 核实 id，不再无声假装发送成功。

同时把版本号提到 `0.2.0-beta.25`（`package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json`）。

## 验证

- `cargo build`：通过
- `pnpm tauri build`（完整生产构建，NSIS 安装包已生成 `BaiyuAISpace_0.2.0-beta.25_x64-setup.exe`）：通过（更新签名步骤因本机未配 `TAURI_SIGNING_PRIVATE_KEY` 报错，与本次改动无关，属已知环境限制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)