### PR TITLE
feat: MCP 预设市场新增钉钉与飞书选项

### DIFF
--- a/src/views/MCPView.vue
+++ b/src/views/MCPView.vue
@@ -233,6 +233,28 @@ const MCP_MARKET_EXTRA: MCPPreset[] = [
     needsConfig: "请将数据库路径改为你本地的 .db 文件路径",
     category: "文件与数据",
   },
+  {
+    id: "dingtalk",
+    name: "钉钉机器人通知",
+    description: "向钉钉群机器人发送文本/Markdown/链接消息，适合任务完成、会话结束等场景的主动通知",
+    serverType: "stdio",
+    command: "npx",
+    args: ["-y", "claude-code-dingtalk-mcp"],
+    needsConfig:
+      "无需预先修改参数：添加后让 AI 调用 dingtalk_configure 工具，传入钉钉群机器人的 Webhook 地址（和可选的加签密钥）即可完成配置",
+    category: "通知与协作",
+  },
+  {
+    id: "feishu-lark",
+    name: "飞书 / Lark 官方工具集",
+    description: "飞书官方 OpenAPI MCP，覆盖消息、文档、多维表格、知识库、日历等接口，可读写飞书工作区内容",
+    serverType: "stdio",
+    command: "npx",
+    args: ["-y", "@larksuiteoapi/lark-mcp", "mcp", "-a", "your_app_id", "-s", "your_app_secret"],
+    needsConfig:
+      "请将 -a 后的值改为飞书应用的 App ID，-s 后的值改为 App Secret（在飞书开放平台创建企业自建应用后获取）",
+    category: "通知与协作",
+  },
 ];
 
 /** 市场目录 = 推荐能力里的预设 + 市场专属条目，二者共享同一套"填表单/查状态"逻辑 */


### PR DESCRIPTION
## 改动内容

`src/views/MCPView.vue` 的 `MCP_MARKET_EXTRA`（MCP 市场专属预设，不进首页"推荐能力"卡片，只在市场里可搜到）新增两条：

- **钉钉机器人通知**（`claude-code-dingtalk-mcp`）：`npx -y claude-code-dingtalk-mcp` 零配置启动，`needsConfig` 提示用户添加后让 AI 调用其 `dingtalk_configure` 工具动态传入 Webhook 地址（和可选加签密钥）。
- **飞书 / Lark 官方工具集**（`@larksuiteoapi/lark-mcp`）：`npx -y @larksuiteoapi/lark-mcp mcp -a your_app_id -s your_app_secret`，覆盖消息/文档/多维表格/知识库/日历等接口，`needsConfig` 提示改 `-a`/`-s` 为真实 App ID/Secret，沿用仓库里 postgres/git 预设"占位参数 + 提示语"的既有模式。

新增分类"通知与协作"，由条目 `category` 字段自动去重生成，无需额外注册。

## 为什么没用 env 变量

市面上大多数钉钉/飞书 MCP 实现（含钉钉官方 `open-dingtalk/dingtalk-mcp`）只支持环境变量传密钥，但现有添加表单目前没有 env 编辑框（`handleCreate` 里硬编码 `env: {}`）——这也是代码里原有注释里"GitHub/Slack 官方 MCP 暂不收录"的同一限制。飞书官方实现恰好支持 `-a`/`-s` 命令行参数，钉钉这边选了支持"零配置启动 + 运行时工具动态配置"的社区实现，两者都不需要碰表单代码即可收录进预设。

## 测试计划

- [x] `pnpm build`（vue-tsc 类型检查 + vite build）通过
- [x] `cargo build`（后端，未涉及改动但作为完整性门禁）通过
- [ ] 手动在 MCP 市场页面搜索验证两条新预设展示正常、点击后表单填充正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)
