### PR TITLE
feat: 增加 Token 计数并完善 beta26 发布流程

### DIFF
--- a/.github/scripts/is-newer-semver.mjs
+++ b/.github/scripts/is-newer-semver.mjs
@@ -1,0 +1,67 @@
+function parseSemver(value) {
+  const match = String(value)
+    .trim()
+    .replace(/^v/, "")
+    .match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/);
+
+  if (!match) {
+    throw new Error(`无法解析版本号: ${value}`);
+  }
+
+  return {
+    core: [BigInt(match[1]), BigInt(match[2]), BigInt(match[3])],
+    prerelease: match[4] ? match[4].split(".") : null,
+  };
+}
+
+function compareIdentifiers(left, right) {
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+
+  if (leftNumeric && rightNumeric) {
+    const leftNumber = BigInt(left);
+    const rightNumber = BigInt(right);
+    return leftNumber === rightNumber ? 0 : leftNumber > rightNumber ? 1 : -1;
+  }
+  if (leftNumeric !== rightNumeric) {
+    return leftNumeric ? -1 : 1;
+  }
+  return left === right ? 0 : left > right ? 1 : -1;
+}
+
+function compareSemver(leftValue, rightValue) {
+  const left = parseSemver(leftValue);
+  const right = parseSemver(rightValue);
+
+  for (let index = 0; index < left.core.length; index += 1) {
+    if (left.core[index] !== right.core[index]) {
+      return left.core[index] > right.core[index] ? 1 : -1;
+    }
+  }
+
+  if (left.prerelease === null || right.prerelease === null) {
+    if (left.prerelease === right.prerelease) return 0;
+    return left.prerelease === null ? 1 : -1;
+  }
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+    if (leftIdentifier === undefined || rightIdentifier === undefined) {
+      if (leftIdentifier === rightIdentifier) return 0;
+      return leftIdentifier === undefined ? -1 : 1;
+    }
+    const result = compareIdentifiers(leftIdentifier, rightIdentifier);
+    if (result !== 0) return result;
+  }
+
+  return 0;
+}
+
+const [candidateVersion, currentVersion] = process.argv.slice(2);
+if (!candidateVersion || !currentVersion) {
+  throw new Error("用法: node is-newer-semver.mjs <candidate> <current>");
+}
+
+process.stdout.write(compareSemver(candidateVersion, currentVersion) > 0 ? "true" : "false");

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -25,11 +25,15 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: '要同步 latest.json 的已发布 Release 标签，例如 v0.2.0-beta.4'
+        description: "要同步 latest.json 的已发布 Release 标签，例如 v0.2.0-beta.4"
         required: true
 
 permissions:
   contents: write
+
+concurrency:
+  group: publish-update-manifest
+  cancel-in-progress: false
 
 jobs:
   publish-update-manifest:
@@ -41,6 +45,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TARGET_TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download latest.json from the published release
         run: gh release download "$TARGET_TAG" --repo ${{ github.repository }} --pattern latest.json --dir manifest --clobber
 
@@ -58,7 +64,27 @@ jobs:
             --notes "仅供应用内 Beta 自动更新读取 latest.json，跟踪最新的任意发布（正式版或 Beta），不代表实际版本发布。" \
             --prerelease --latest=false
 
+      - name: Prevent Beta manifest version rollback
+        id: beta-version
+        run: |
+          TARGET_VERSION=$(jq -r .version manifest/latest.json)
+          mkdir -p current-beta
+          if gh release download updater-manifest-beta --repo ${{ github.repository }} \
+            --pattern latest.json --dir current-beta --clobber; then
+            CURRENT_VERSION=$(jq -r .version current-beta/latest.json)
+          else
+            CURRENT_VERSION="0.0.0-0"
+          fi
+          SHOULD_PUBLISH=$(node .github/scripts/is-newer-semver.mjs "$TARGET_VERSION" "$CURRENT_VERSION")
+          echo "target_version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "should_publish=$SHOULD_PUBLISH" >> "$GITHUB_OUTPUT"
+          if [ "$SHOULD_PUBLISH" != "true" ]; then
+            echo "::notice::Skip Beta manifest rollback: candidate $TARGET_VERSION is not newer than $CURRENT_VERSION"
+          fi
+
       - name: Publish latest.json to the Beta channel release
+        if: steps.beta-version.outputs.should_publish == 'true'
         run: gh release upload updater-manifest-beta manifest/latest.json --repo ${{ github.repository }} --clobber
 
       - name: Ensure fixed updater-manifest release exists
@@ -70,6 +96,26 @@ jobs:
             --notes "仅供应用内自动更新读取 latest.json，不代表实际版本发布，安装包请在正式版本 Release 里下载。" \
             --prerelease --latest=false
 
-      - name: Publish latest.json to the stable channel release
+      - name: Prevent stable manifest version rollback
         if: steps.release-kind.outputs.is_prerelease == 'false'
+        id: stable-version
+        run: |
+          TARGET_VERSION=$(jq -r .version manifest/latest.json)
+          mkdir -p current-stable
+          if gh release download updater-manifest --repo ${{ github.repository }} \
+            --pattern latest.json --dir current-stable --clobber; then
+            CURRENT_VERSION=$(jq -r .version current-stable/latest.json)
+          else
+            CURRENT_VERSION="0.0.0-0"
+          fi
+          SHOULD_PUBLISH=$(node .github/scripts/is-newer-semver.mjs "$TARGET_VERSION" "$CURRENT_VERSION")
+          echo "target_version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "should_publish=$SHOULD_PUBLISH" >> "$GITHUB_OUTPUT"
+          if [ "$SHOULD_PUBLISH" != "true" ]; then
+            echo "::notice::Skip stable manifest rollback: candidate $TARGET_VERSION is not newer than $CURRENT_VERSION"
+          fi
+
+      - name: Publish latest.json to the stable channel release
+        if: steps.release-kind.outputs.is_prerelease == 'false' && steps.stable-version.outputs.should_publish == 'true'
         run: gh release upload updater-manifest manifest/latest.json --repo ${{ github.repository }} --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
@@ -58,6 +60,25 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
+      # Annotated Tag 的正文就是人工确认过的更新说明。把它直接带进草稿 Release，
+      # 避免构建完成后只剩安装包说明、漏写本次实际更新内容。
+      - name: Prepare release notes from annotated tag
+        id: release-notes
+        shell: pwsh
+        run: |
+          $tagNotes = (git for-each-ref "refs/tags/$env:GITHUB_REF_NAME" --format="%(contents)" | Out-String).Trim()
+          if ([string]::IsNullOrWhiteSpace($tagNotes)) {
+            $tagNotes = "更新内容：`n`n- 请在发布前补充本次更新内容。"
+          }
+          $body = @"
+          $tagNotes
+
+          各平台安装包见下方 Assets。Windows 提供 .exe 安装包（NSIS）和便携版单文件 exe（免安装，双击运行），macOS 用 .dmg，Linux 用 .AppImage。
+          "@
+          "body<<RELEASE_BODY_EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $body.Trim() | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "RELEASE_BODY_EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
       # tauri-action 会自动执行 beforeBuildCommand（pnpm build）、
       # 打包 tauri.conf.json 里声明的 targets，并把产物挂到 Release
       - uses: tauri-apps/tauri-action@v0
@@ -69,7 +90,7 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'BaiyuAISpace ${{ github.ref_name }}'
-          releaseBody: '各平台安装包见下方 Assets。Windows 提供 .exe 安装包（NSIS）和便携版单文件 exe（免安装，双击运行），macOS 用 .dmg，Linux 用 .AppImage。'
+          releaseBody: ${{ steps.release-notes.outputs.body }}
           releaseDraft: true
           # 带 “-” 的标签（如 v0.2.0-beta.1）自动标为预发布版本
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baiyu-aispace",
   "private": true,
-  "version": "0.2.0-beta.25",
+  "version": "0.2.0-beta.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "BaiyuAISpace2"
-version = "0.2.0-beta.25"
+version = "0.2.0-beta.26"
 description = "轻量级跨平台 AI Agent 开发环境"
 authors = ["Baiyu"]
 license = "MPL-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "BaiyuAISpace",
-  "version": "0.2.0-beta.25",
+  "version": "0.2.0-beta.26",
   "identifier": "com.baiyu.aispace",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -31,6 +31,8 @@ import { NAvatar, NIcon, NSpin, NAlert, NTooltip } from "naive-ui";
 // 聊天 Store - 编辑/重新生成都要落库并重新发起生成请求，这两件事和消息本身
 // 的截断/删除逻辑都在 store 里，组件只负责触发
 import { useChatStore } from "@/stores/chat";
+import TokenCount from "@/components/TokenCount.vue";
+import { estimateTokenCount } from "@/utils/tokenCount";
 
 // Markdown 渲染管线。marked/KaTeX/DOMPurify/hljs/Mermaid 的全局配置都在该
 // 模块顶层完成，整个应用只执行一次——不能放回本组件的 <script setup>：
@@ -140,6 +142,9 @@ const isAssistant = computed(() => props.message.role === "assistant");
 // 渲染后的 Markdown 内容（解析、净化、HTML/Mermaid 预览块生成全部在
 // utils/markdown.ts 的 renderMarkdown 里完成）
 const renderedContent = computed(() => renderMarkdown(props.message.content));
+
+// 流式输出期间也随正文实时更新；只统计消息可见文本。
+const messageTokenCount = computed(() => estimateTokenCount(props.message.content));
 
 // ============ 方法函数 ============
 
@@ -376,6 +381,11 @@ const handleRegenerate = async () => {
         </n-alert>
       </div>
 
+      <TokenCount
+        class="message-token-count"
+        :count="messageTokenCount"
+      />
+
       <!-- Actions -->
       <div
         v-if="!message.streaming && !isEditing"
@@ -497,6 +507,10 @@ const handleRegenerate = async () => {
   color: $ink-faint;
   font-size: 12px;
   font-family: $font-mono;
+}
+
+.message-token-count {
+  padding: 0 4px;
 }
 
 .message-body {

--- a/src/components/TokenCount.vue
+++ b/src/components/TokenCount.vue
@@ -1,0 +1,57 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { formatTokenCount } from "@/utils/tokenCount";
+
+const props = withDefaults(defineProps<{
+  count: number;
+  label?: string;
+  description?: string;
+}>(), {
+  label: "",
+  description: "估算值，仅统计可见文本；不含图片、隐藏系统提示词和工具上下文",
+});
+
+const formattedCount = computed(() => formatTokenCount(props.count));
+</script>
+
+<template>
+  <span
+    class="token-count"
+    :title="description"
+  >
+    <span
+      v-if="label"
+      class="token-label"
+    >{{ label }}</span>
+    <span class="token-value">≈ {{ formattedCount }} Tokens</span>
+  </span>
+</template>
+
+<style scoped lang="scss">
+.token-count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  color: $ink-faint;
+  font-family: $font-mono;
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.token-label {
+  font-family: $font-sans;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.token-value {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/src/utils/tokenCount.ts
+++ b/src/utils/tokenCount.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Token 计数只能是跨模型近似值：OpenAI、Anthropic、Gemini 以及本地模型
+ * 使用的 tokenizer 并不相同，前端也拿不到所有服务商的实际 usage。
+ *
+ * 这里按可见文本做稳定、即时的估算：
+ * - 中日韩文字按每个字符约 1 token；
+ * - 连续字母/数字按长度约每 4 个字符 1 token，短词至少 1 token；
+ * - 标点、符号和 emoji 各按约 1 token。
+ *
+ * 图片、视频、隐藏系统提示词、RAG 上下文和工具调用上下文不计入。
+ */
+
+const CJK_CHAR =
+  /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]/u;
+const WORD_SEGMENT = /^[\p{L}\p{N}_]+$/u;
+const TEXT_SEGMENTS =
+  /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]|[\p{L}\p{N}_]+|[^\s]/gu;
+
+export interface TokenCountableMessage {
+  content: string;
+}
+
+export function estimateTokenCount(text: string): number {
+  if (!text.trim()) return 0;
+
+  const segments = text.normalize("NFC").match(TEXT_SEGMENTS) ?? [];
+  return segments.reduce((total, segment) => {
+    if (CJK_CHAR.test(segment)) return total + 1;
+    if (WORD_SEGMENT.test(segment)) {
+      return total + Math.max(1, Math.round(Array.from(segment).length / 4));
+    }
+    return total + 1;
+  }, 0);
+}
+
+export function countMessageTokens(messages: readonly TokenCountableMessage[]): number {
+  return messages.reduce((total, message) => total + estimateTokenCount(message.content), 0);
+}
+
+export function formatTokenCount(count: number): string {
+  return Math.max(0, Math.round(count)).toLocaleString("zh-CN");
+}

--- a/src/views/AgentTeamView.vue
+++ b/src/views/AgentTeamView.vue
@@ -27,6 +27,8 @@ import {
 } from "@vicons/ionicons5";
 
 import ChatMessage from "@/components/ChatMessage.vue";
+import TokenCount from "@/components/TokenCount.vue";
+import { countMessageTokens } from "@/utils/tokenCount";
 import {
   useWorkspaceStore, AGENT_GUIDELINES_BASE, AGENT_GUIDELINES_SUB,
   type AgentProposalEvent, type AgentRole, type AgentStatus, type CreateAgentRequest,
@@ -424,6 +426,10 @@ const agentMessages = computed(() => {
     }));
 });
 
+/** 当前工作组与所选 Agent 对话中，已经加载到前端的可见文本 Token。 */
+const workspaceTokenCount = computed(() => countMessageTokens(workspace.messages));
+const agentTokenCount = computed(() => countMessageTokens(agentMessages.value));
+
 // 待发送的图片附件（base64；发送给支持视觉的模型，并随消息入库）
 const attachedMsgImages = ref<{ name: string; data: string; mediaType: string }[]>([]);
 const msgImageInputRef = ref<HTMLInputElement | null>(null);
@@ -777,7 +783,16 @@ onBeforeUnmount(() => {
           协作团队
         </h1>
       </div>
-      <n-space>
+      <n-space align="center">
+        <TokenCount
+          v-if="workspace.currentWorkspace"
+          :label="workspace.hasMoreMessages ? '已载入工作组' : '当前工作组'"
+          :count="workspaceTokenCount"
+          :description="workspace.hasMoreMessages
+            ? '估算值，仅统计已经加载的工作组消息；点击加载更早消息后会继续累加'
+            : '估算值，仅统计工作组消息的可见文本；不含图片、系统提示词和工具上下文'"
+          class="workspace-token-count"
+        />
         <n-select
           :value="workspace.currentWorkspaceId"
           :options="workspaceOptions"
@@ -1223,8 +1238,17 @@ onBeforeUnmount(() => {
             <template #header-extra>
               <n-space
                 v-if="selectedAgent"
+                align="center"
                 size="small"
               >
+                <TokenCount
+                  :label="workspace.hasMoreMessages ? '已载入对话' : '当前对话'"
+                  :count="agentTokenCount"
+                  :description="workspace.hasMoreMessages
+                    ? '估算值，仅统计已经加载且与当前 Agent 相关的消息'
+                    : '估算值，仅统计当前 Agent 对话的可见文本'"
+                  class="agent-token-count"
+                />
                 <n-button
                   size="small"
                   quaternary
@@ -2030,6 +2054,12 @@ onBeforeUnmount(() => {
   flex-direction: column;
   align-items: flex-start;
   gap: 0.75rem;
+}
+
+.workspace-token-count,
+.agent-token-count {
+  padding-right: 12px;
+  border-right: $border-faint;
 }
 
 .page-title {

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -24,6 +24,8 @@ import { useChatStore } from "@/stores/chat";
 import { useSettingsStore } from "@/stores/settings";
 import ChatMessage from "@/components/ChatMessage.vue";
 import ChatInput from "@/components/ChatInput.vue";
+import TokenCount from "@/components/TokenCount.vue";
+import { countMessageTokens } from "@/utils/tokenCount";
 
 // ============ 状态管理 ============
 
@@ -45,6 +47,11 @@ const messagesContainer = ref<HTMLDivElement | null>(null);
 const hasMessages = computed(() => {
   return chat.currentSession && chat.currentSession.messages.length > 0;
 });
+
+/** 当前会话全部可见消息的文本 Token 估算，流式输出时实时增长。 */
+const sessionTokenCount = computed(() =>
+  countMessageTokens(chat.currentSession?.messages ?? [])
+);
 
 // ============ 方法函数 ============
 
@@ -102,6 +109,17 @@ onMounted(async () => {
 <template>
   <!-- 聊天主布局容器 -->
   <div class="chat-view">
+    <div
+      v-if="chat.currentSession"
+      class="session-token-bar"
+    >
+      <span class="session-token-eyebrow">Session Context</span>
+      <TokenCount
+        label="本会话"
+        :count="sessionTokenCount"
+      />
+    </div>
+
     <!-- 消息区域 (滚动容器) -->
     <div
       ref="messagesContainer"
@@ -222,6 +240,26 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   background: $bg;
+}
+
+.session-token-bar {
+  min-height: 36px;
+  padding: 0 32px;
+  border-bottom: $border-faint;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: $bg;
+}
+
+.session-token-eyebrow {
+  color: $ink-faint;
+  font-family: $font-sans;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: $label-tracking;
+  text-transform: uppercase;
 }
 
 /* 消息区域 - 占据剩余空间并承担滚动 */

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -19,14 +19,16 @@
 -->
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { NEmpty, NList, NListItem, NThing, NTag, NText, NButton, NIcon, NSpin, NPopconfirm, NSpace, NDropdown, useMessage, type DropdownOption } from "naive-ui";
 import { save } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
-import { useChatStore } from "@/stores/chat";
+import { useChatStore, type ChatSession } from "@/stores/chat";
 import { buildConversationExport, type ExportFormat } from "@/utils/exportConversation";
 import { ChatbubblesOutline, TrashOutline, EnterOutline, DownloadOutline } from "@vicons/ionicons5";
+import TokenCount from "@/components/TokenCount.vue";
+import { countMessageTokens } from "@/utils/tokenCount";
 
 // ============ 路由和状态管理 ============
 
@@ -43,6 +45,14 @@ const message = useMessage();
 
 /** 加载状态 - 显示加载动画 */
 const loading = ref(false);
+
+/** 当前已加载的全部历史会话可见文本 Token 估算。 */
+const historyTokenCount = computed(() =>
+  chat.sessions.reduce(
+    (total: number, session: ChatSession) => total + countMessageTokens(session.messages),
+    0
+  )
+);
 
 // ============ 方法函数 ============
 
@@ -163,9 +173,15 @@ onMounted(() => {
         <!-- 页面标题 -->
         <header class="page-header enter-up">
           <span class="eyebrow">History</span>
-          <h1 class="page-title">
-            历史记录
-          </h1>
+          <div class="page-heading-row">
+            <h1 class="page-title">
+              历史记录
+            </h1>
+            <TokenCount
+              label="全部历史"
+              :count="historyTokenCount"
+            />
+          </div>
           <p class="page-desc">
             所有对话会话的存档，点击任意条目继续对话。
           </p>
@@ -255,6 +271,10 @@ onMounted(() => {
                   >
                     {{ session.messages.length }} 条消息
                   </n-text>
+                  <TokenCount
+                    label="会话"
+                    :count="countMessageTokens(session.messages)"
+                  />
                 </n-space>
               </template>
               
@@ -372,6 +392,13 @@ onMounted(() => {
   font-weight: 700;
   line-height: $leading-display;
   color: $ink;
+}
+
+.page-heading-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
 }
 
 /* 页面描述 */


### PR DESCRIPTION
## 改动内容

- Chat 当前会话新增总 Token 估算，每条消息下方显示该消息的 Token 估算。
- History 显示全部历史总量及每个会话的 Token 估算。
- Agent Team 显示工作组、当前 Agent 对话及单条消息的 Token 估算。
- Token 数仅按可见文本跨模型估算，不包含图片、隐藏系统提示词、RAG 和工具上下文。
- 版本号统一升至 `0.2.0-beta.26`。
- Release 工作流从 annotated tag 读取更新内容，避免 Release 正文遗漏实际更新说明。
- 更新清单工作流增加串行控制和语义版本比较，阻止旧版本晚发布时覆盖较新的 Beta/正式版清单。

## 用户影响

用户可以在 Chat、History 和 Agent Team 中快速判断当前会话规模；同时修复 beta25 遇到的“检测到新版本，但自动安装清单被旧版本覆盖”的发布流程隐患。

## 验证

- [x] Chat、History、Agent Team Token 展示已在隔离实例中完成真实界面验证。
- [x] 语义版本比较脚本覆盖新版本、相同版本、旧版本及 prerelease 场景。
- [x] `git diff --check` 通过。
- [ ] 本次重跑 `pnpm build` 前的依赖恢复被 Windows 占用 `esbuild` 目录阻断，未进入代码编译阶段；以本 PR 的远程 CI 作为最终构建门禁。

## 备注

PR #93 与本 PR 不修改同一文件，可按任意顺序合并。
