### PR TITLE
fix: 修复 RAG 中文检索与降级提示

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ once_cell = "1.19"
 scopeguard = "1.2"
 urlencoding = "2.1"
 scraper = "0.20"
+jieba-rs = "=0.7.4"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/knowledge_base/commands.rs
+++ b/src-tauri/src/knowledge_base/commands.rs
@@ -7,6 +7,7 @@ use super::document::{parse_document, calculate_file_hash, split_text, estimate_
 use super::embedding::generate_embeddings;
 use super::db::{VectorStore, init_sqlite_tables};
 use super::retrieval::Retriever;
+use super::search_text::tokenize_for_fts;
 use tauri::State;
 use std::sync::Arc;
 
@@ -355,9 +356,10 @@ pub async fn import_document(
             ).map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
 
             // 写入 FTS5 —— 出错时记日志而不是直接忽略
+            let search_text = tokenize_for_fts(chunk_text);
             if let Err(e) = conn.execute(
                 "INSERT INTO chunks_fts (rowid, kb_id, content) VALUES (last_insert_rowid(), ?1, ?2)",
-                rusqlite::params![&kb_id, chunk_text],
+                rusqlite::params![&kb_id, search_text],
             ) {
                 log::warn!("[KB] FTS5 insert failed for chunk {}: {}", chunk_id, e);
             }
@@ -606,11 +608,18 @@ pub async fn search_knowledge_base(
         let conn = rusqlite::Connection::open(&kb_state.db_path)
             .map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
 
-        let (config_id, provider, model, base_url): (String, String, String, String) = conn.query_row(
-            "SELECT embedding_api_config_id, COALESCE(embedding_provider, ''), COALESCE(embedding_model, ''), COALESCE(embedding_base_url, '') FROM knowledge_bases WHERE id = ?1",
-            [&request.kb_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-        ).map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
+        let (config_id, provider, model, base_url): (String, String, String, String) = conn
+            .query_row(
+                "SELECT embedding_api_config_id, COALESCE(embedding_provider, ''), COALESCE(embedding_model, ''), COALESCE(embedding_base_url, '') FROM knowledge_bases WHERE id = ?1",
+                [&request.kb_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    KnowledgeBaseError::NotFound(request.kb_id.clone())
+                }
+                other => KnowledgeBaseError::DatabaseError(other.to_string()),
+            })?;
 
         // 仅对创建于 embedding_provider/model 字段引入之前的旧知识库，
         // 才回退到 OpenAI 默认值。
@@ -635,6 +644,7 @@ pub async fn search_knowledge_base(
                     let base_url = request.reranker_base_url.as_deref().unwrap_or("");
                     let model = request.reranker_model.as_deref().unwrap_or("");
                     let top_n = request.rerank_top_n.unwrap_or(request.top_k) as usize;
+                    let unranked_chunks = result.chunks.clone();
                     match super::reranker::rerank_chunks(
                         &request.query,
                         result.chunks,
@@ -649,13 +659,25 @@ pub async fn search_knowledge_base(
                         }
                         Err(e) => {
                             log::warn!("[KB] Reranker failed, returning unranked results: {}", e);
-                            result.chunks = vec![];
-                            result.total_chunks = 0;
+                            result.chunks = unranked_chunks;
+                            result.total_chunks = result.chunks.len() as i32;
+                            result.warnings.push(RetrievalWarning {
+                                code: "reranker_fallback".to_string(),
+                                message:
+                                    "Reranker 精排暂时不可用，已自动使用原始检索结果。"
+                                        .to_string(),
+                            });
                         }
                     }
                 }
                 Err(e) => {
                     log::warn!("[KB] Could not load reranker API key: {}", e);
+                    result.warnings.push(RetrievalWarning {
+                        code: "reranker_fallback".to_string(),
+                        message:
+                            "Reranker 配置不可用，已自动使用原始检索结果，请检查精排配置。"
+                                .to_string(),
+                    });
                 }
             }
         }

--- a/src-tauri/src/knowledge_base/db.rs
+++ b/src-tauri/src/knowledge_base/db.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::search_text::tokenize_for_fts;
 use super::types::*;
 
 /// 基于 SQLite、用余弦相似度做检索的向量存储
@@ -465,19 +466,15 @@ pub fn init_sqlite_tables(conn: &rusqlite::Connection) -> Result<(), rusqlite::E
         [],
     )?;
 
-    // 用于全文检索的 FTS5 虚拟表（可选，取决于 FTS5 是否可用）
-    // 对应 #29、#30 的修复：加入 kb_id 列以实现知识库之间的隔离
-    let _ = conn.execute(
-        r#"
-        CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
-            kb_id,
-            content,
-            content_rowid=rowid,
-            tokenize='porter'
-        )
-        "#,
-        [],
-    );
+    // 用于全文检索的 FTS5 虚拟表（可选，取决于 FTS5 是否可用）。
+    // 旧表使用 porter，只适合英文；现在文档在写入索引前先经中文分词，
+    // 再交给 unicode61 索引。初始化时会自动重建旧索引，不触碰原文和向量。
+    if let Err(e) = ensure_chinese_fts_index(conn) {
+        log::warn!(
+            "[KB] 中文关键词索引初始化失败，将在检索时回退到 LIKE: {}",
+            e
+        );
+    }
 
     // 索引
     conn.execute(
@@ -512,6 +509,66 @@ pub fn init_sqlite_tables(conn: &rusqlite::Connection) -> Result<(), rusqlite::E
     )?;
 
     log::info!("Knowledge base SQLite tables initialized");
+    Ok(())
+}
+
+fn ensure_chinese_fts_index(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
+    const CREATE_FTS_SQL: &str = r#"
+        CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+            kb_id UNINDEXED,
+            content,
+            tokenize='unicode61 remove_diacritics 2'
+        )
+    "#;
+
+    let existing_sql: Option<String> = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'chunks_fts'",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+
+    let chunks_count: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))?;
+    let indexed_count: i64 = if existing_sql.is_some() {
+        conn.query_row("SELECT COUNT(*) FROM chunks_fts", [], |row| row.get(0))
+            .unwrap_or(-1)
+    } else {
+        -1
+    };
+
+    let uses_chinese_index = existing_sql
+        .as_deref()
+        .map(|sql| sql.to_ascii_lowercase().contains("unicode61"))
+        .unwrap_or(false);
+    let needs_rebuild = !uses_chinese_index || indexed_count != chunks_count;
+
+    if !needs_rebuild {
+        return Ok(());
+    }
+
+    conn.execute("DROP TABLE IF EXISTS chunks_fts", [])?;
+    conn.execute(CREATE_FTS_SQL, [])?;
+
+    let rows: Vec<(i64, String, String)> = {
+        let mut stmt = conn.prepare("SELECT rowid, kb_id, content FROM chunks ORDER BY rowid")?;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+        rows
+    };
+
+    let mut insert =
+        conn.prepare("INSERT INTO chunks_fts (rowid, kb_id, content) VALUES (?1, ?2, ?3)")?;
+    for (rowid, kb_id, content) in &rows {
+        let search_text = tokenize_for_fts(content);
+        insert.execute(rusqlite::params![rowid, kb_id, search_text])?;
+    }
+
+    log::info!(
+        "[KB] 中文关键词索引已重建，共写入 {} 个分块（无需重新生成向量）",
+        rows.len()
+    );
     Ok(())
 }
 

--- a/src-tauri/src/knowledge_base/mod.rs
+++ b/src-tauri/src/knowledge_base/mod.rs
@@ -20,4 +20,5 @@ pub mod document;
 pub mod embedding;
 pub mod reranker;
 pub mod retrieval;
+pub mod search_text;
 pub mod types;

--- a/src-tauri/src/knowledge_base/reranker.rs
+++ b/src-tauri/src/knowledge_base/reranker.rs
@@ -79,6 +79,12 @@ pub async fn rerank_chunks(
         })
         .collect();
 
+    if reranked.is_empty() {
+        return Err(KnowledgeBaseError::RetrievalError(
+            "Reranker response contained no valid results".to_string(),
+        ));
+    }
+
     reranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
     Ok(reranked)

--- a/src-tauri/src/knowledge_base/retrieval.rs
+++ b/src-tauri/src/knowledge_base/retrieval.rs
@@ -5,6 +5,8 @@
 use super::types::*;
 use super::db::VectorStore;
 use super::embedding::generate_single_embedding;
+use super::search_text::{build_fts_query, extract_query_terms, keyword_coverage};
+use rusqlite::types::Value;
 use std::sync::Arc;
 
 pub struct Retriever {
@@ -146,6 +148,7 @@ impl Retriever {
             query: request.query.clone(),
             total_chunks: filtered_chunks.len() as i32,
             chunks: filtered_chunks,
+            warnings: Vec::new(),
         })
     }
 
@@ -165,14 +168,21 @@ impl Retriever {
                 .map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
 
             // 优先尝试 FTS5，失败则回退到 LIKE 查询
-            Self::search_with_fts_blocking(&conn, &kb_id, &query, top_k)
-                .or_else(|_| Self::search_with_like_blocking(&conn, &kb_id, &query, top_k))
+            match Self::search_with_fts_blocking(&conn, &kb_id, &query, top_k) {
+                Ok(chunks) if !chunks.is_empty() => Ok(chunks),
+                Ok(_) => Self::search_with_like_blocking(&conn, &kb_id, &query, top_k),
+                Err(e) => {
+                    log::warn!("[KB] FTS5 检索失败，回退到 LIKE: {}", e);
+                    Self::search_with_like_blocking(&conn, &kb_id, &query, top_k)
+                }
+            }
         }).await.map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))??;
 
         Ok(RetrievalResult {
             query: request.query.clone(),
             total_chunks: chunks.len() as i32,
             chunks,
+            warnings: Vec::new(),
         })
     }
 
@@ -224,6 +234,7 @@ impl Retriever {
             query: request.query.clone(),
             total_chunks: filtered.len() as i32,
             chunks: filtered,
+            warnings: Vec::new(),
         })
     }
 
@@ -367,55 +378,67 @@ impl Retriever {
 
         // 构建 FTS 查询：转义特殊字符，并把每个词用双引号包起来
         // FTS5 的特殊字符包括：" * ( ) : ^ [ ] { } + - AND OR NOT NEAR
-        let fts_query: String = query
-            .split_whitespace()
-            .map(|term| {
-                // 转义词内部的双引号
-                let escaped = term.replace('"', "\"\"");
-                format!("\"{}\"", escaped)
-            })
-            .collect::<Vec<_>>()
-            .join(" ");
+        let Some((fts_query, terms)) = build_fts_query(query) else {
+            return Ok(Vec::new());
+        };
+        let candidate_limit = top_k.max(1).saturating_mul(4);
 
         let mut stmt = conn.prepare(
             r#"
             SELECT c.id, c.document_id, c.content, c.chunk_index, c.token_count, d.filename,
-                   rank
-            FROM chunks_fts fts
-            JOIN chunks c ON fts.rowid = c.rowid
+                   bm25(chunks_fts) AS fts_rank
+            FROM chunks_fts
+            JOIN chunks c ON chunks_fts.rowid = c.rowid
             JOIN documents d ON c.document_id = d.id
-            WHERE fts.kb_id = ?1 AND fts MATCH ?2
-            ORDER BY rank
+            WHERE chunks_fts.kb_id = ?1 AND chunks_fts MATCH ?2
+            ORDER BY fts_rank
             LIMIT ?3
             "#
         ).map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
 
         let rows = stmt.query_map(
-            rusqlite::params![kb_id, &fts_query, top_k],
+            rusqlite::params![kb_id, &fts_query, candidate_limit],
             |row| {
-                Ok(RetrievedChunk {
-                    chunk: Chunk {
-                        id: row.get(0)?,
-                        document_id: row.get(1)?,
-                        kb_id: kb_id.to_string(),
-                        content: row.get(2)?,
-                        chunk_index: row.get(3)?,
-                        token_count: row.get(4)?,
+                let content: String = row.get(2)?;
+                let coverage = keyword_coverage(&content, &terms);
+                Ok((
+                    RetrievedChunk {
+                        chunk: Chunk {
+                            id: row.get(0)?,
+                            document_id: row.get(1)?,
+                            kb_id: kb_id.to_string(),
+                            content,
+                            chunk_index: row.get(3)?,
+                            token_count: row.get(4)?,
+                        },
+                        score: coverage,
+                        vector_score: None,
+                        keyword_score: Some(coverage),
+                        document_filename: row.get(5)?,
                     },
-                    score: 1.0, // FTS 不会直接给出 0-1 范围的分数
-                    vector_score: None,
-                    keyword_score: Some(1.0),
-                    document_filename: row.get(5)?,
-                })
+                    row.get::<_, f64>(6)?,
+                ))
             }
         ).map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
 
-        let mut chunks = Vec::new();
+        let mut ranked = Vec::new();
         for row in rows {
-            chunks.push(row.map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?);
+            ranked.push(row.map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?);
         }
 
-        Ok(chunks)
+        ranked.sort_by(|(a, a_rank), (b, b_rank)| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| {
+                    a_rank
+                        .partial_cmp(b_rank)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+        });
+        ranked.truncate(top_k.max(0) as usize);
+
+        Ok(ranked.into_iter().map(|(chunk, _)| chunk).collect())
     }
 
     /// 使用 LIKE 查询进行搜索（FTS 不可用时的回退方案）—— 阻塞版本
@@ -427,42 +450,59 @@ impl Retriever {
         top_k: i32,
     ) -> Result<Vec<RetrievedChunk>, KnowledgeBaseError> {
         // 构建带通配符的 LIKE 模式，同时转义 LIKE 的特殊字符
-        let escaped_terms: Vec<String> = query
-            .split_whitespace()
-            .map(|term| {
-                // 转义 % 和 _ 字符
-                let escaped = term.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
-                escaped
-            })
-            .collect();
+        let terms = extract_query_terms(query);
+        if terms.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        let pattern = format!("%{}%", escaped_terms.join("%"));
-
-        let mut stmt = conn.prepare(
+        let candidate_limit = top_k.max(1).saturating_mul(8);
+        let conditions = (0..terms.len())
+            .map(|index| format!("c.content LIKE ?{} ESCAPE '\\'", index + 2))
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        let limit_param = terms.len() + 2;
+        let sql = format!(
             r#"
             SELECT c.id, c.document_id, c.content, c.chunk_index, c.token_count, d.filename
             FROM chunks c
             JOIN documents d ON c.document_id = d.id
-            WHERE c.kb_id = ?1 AND c.content LIKE ?2 ESCAPE '\'
-            LIMIT ?3
-            "#
+            WHERE c.kb_id = ?1 AND ({})
+            LIMIT ?{}
+            "#,
+            conditions, limit_param
+        );
+        let mut stmt = conn.prepare(
+            &sql
         ).map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?;
 
+        let mut values = Vec::with_capacity(terms.len() + 2);
+        values.push(Value::Text(kb_id.to_string()));
+        for term in &terms {
+            let escaped = term
+                .replace('\\', "\\\\")
+                .replace('%', "\\%")
+                .replace('_', "\\_");
+            values.push(Value::Text(format!("%{}%", escaped)));
+        }
+        values.push(Value::Integer(candidate_limit as i64));
+
         let rows = stmt.query_map(
-            rusqlite::params![kb_id, &pattern, top_k],
+            rusqlite::params_from_iter(values.iter()),
             |row| {
+                let content: String = row.get(2)?;
+                let coverage = keyword_coverage(&content, &terms);
                 Ok(RetrievedChunk {
                     chunk: Chunk {
                         id: row.get(0)?,
                         document_id: row.get(1)?,
                         kb_id: kb_id.to_string(),
-                        content: row.get(2)?,
+                        content,
                         chunk_index: row.get(3)?,
                         token_count: row.get(4)?,
                     },
-                    score: 0.5, // LIKE 查询无法给出有意义的分数
+                    score: coverage,
                     vector_score: None,
-                    keyword_score: Some(0.5),
+                    keyword_score: Some(coverage),
                     document_filename: row.get(5)?,
                 })
             }
@@ -472,6 +512,13 @@ impl Retriever {
         for row in rows {
             chunks.push(row.map_err(|e| KnowledgeBaseError::DatabaseError(e.to_string()))?);
         }
+
+        chunks.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        chunks.truncate(top_k.max(0) as usize);
 
         Ok(chunks)
     }
@@ -555,4 +602,93 @@ pub fn build_context(chunks: &[RetrievedChunk], query: &str) -> String {
     context_parts.push(format!("问题：{}", query));
     
     context_parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knowledge_base::search_text::tokenize_for_fts;
+
+    fn setup_keyword_db() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE documents (
+                id TEXT PRIMARY KEY,
+                filename TEXT NOT NULL
+            );
+            CREATE TABLE chunks (
+                id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                kb_id TEXT NOT NULL,
+                content TEXT NOT NULL,
+                chunk_index INTEGER NOT NULL,
+                token_count INTEGER NOT NULL
+            );
+            CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                kb_id UNINDEXED,
+                content,
+                tokenize='unicode61 remove_diacritics 2'
+            );
+            INSERT INTO documents (id, filename) VALUES ('doc-1', '英语教材.docx');
+            "#,
+        )
+        .unwrap();
+
+        let chunks = [
+            (
+                "chunk-irrelevant",
+                "spaceship 是由 space 和 ship 构成的合成词。",
+                0,
+            ),
+            (
+                "chunk-answer",
+                "⑤ better（词性：动词；词义：改善，使更好）。",
+                1,
+            ),
+        ];
+        for (id, content, index) in chunks {
+            conn.execute(
+                "INSERT INTO chunks (id, document_id, kb_id, content, chunk_index, token_count)
+                 VALUES (?1, 'doc-1', 'kb-1', ?2, ?3, 20)",
+                rusqlite::params![id, content, index],
+            )
+            .unwrap();
+            let rowid = conn.last_insert_rowid();
+            conn.execute(
+                "INSERT INTO chunks_fts (rowid, kb_id, content) VALUES (?1, 'kb-1', ?2)",
+                rusqlite::params![rowid, tokenize_for_fts(content)],
+            )
+            .unwrap();
+        }
+
+        conn
+    }
+
+    #[test]
+    fn chinese_fts_question_finds_answer_without_exact_sentence_match() {
+        let conn = setup_keyword_db();
+        let chunks = Retriever::search_with_fts_blocking(
+            &conn,
+            "kb-1",
+            "根据教材，第16题中第二个 better 是什么词性、意思是什么？",
+            5,
+        )
+        .unwrap();
+
+        assert!(!chunks.is_empty());
+        assert_eq!(chunks[0].chunk.id, "chunk-answer");
+        assert!(chunks[0].keyword_score.unwrap_or_default() > 0.0);
+    }
+
+    #[test]
+    fn like_fallback_matches_individual_chinese_terms() {
+        let conn = setup_keyword_db();
+        let chunks =
+            Retriever::search_with_like_blocking(&conn, "kb-1", "请回答 better 的词性和意思", 5)
+                .unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk.id, "chunk-answer");
+    }
 }

--- a/src-tauri/src/knowledge_base/search_text.rs
+++ b/src-tauri/src/knowledge_base/search_text.rs
@@ -1,0 +1,166 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use jieba_rs::Jieba;
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+
+static JIEBA: Lazy<Jieba> = Lazy::new(Jieba::new);
+
+// 这些词描述的是提问动作或 RAG 容器本身，不是用户真正想查的知识。
+// 去掉它们能避免“根据知识库回答一下”之类套话淹没实际关键词。
+const QUERY_STOP_WORDS: &[&str] = &[
+    "一下",
+    "一个",
+    "这个",
+    "那个",
+    "什么",
+    "为什么",
+    "怎么",
+    "如何",
+    "是否",
+    "请问",
+    "请",
+    "回答",
+    "告诉",
+    "根据",
+    "基于",
+    "只按",
+    "关于",
+    "有关",
+    "问题",
+    "内容",
+    "文档",
+    "知识库",
+    "教材",
+    "里面",
+    "中的",
+    "中",
+    "是",
+    "的",
+    "了",
+    "吗",
+    "呢",
+    "和",
+    "与",
+    "或",
+];
+
+fn normalize_token(token: &str) -> Option<String> {
+    let normalized = token.trim().to_lowercase();
+    if normalized.is_empty() || !normalized.chars().any(char::is_alphanumeric) {
+        return None;
+    }
+    Some(normalized)
+}
+
+fn is_significant_query_token(token: &str) -> bool {
+    if QUERY_STOP_WORDS.contains(&token) {
+        return false;
+    }
+
+    // 英文缩写、数字、题号即使只有 1 个字符也可能是关键实体；中文单字通常
+    // 噪声较大，至少保留两个字符。
+    token.chars().any(|c| c.is_ascii_alphanumeric()) || token.chars().count() >= 2
+}
+
+/// 将原文转换为适合 SQLite FTS5 unicode61 tokenizer 的预分词文本。
+/// 原始 chunk 内容仍保存在 chunks 表中，这里只服务于轻量关键词索引。
+pub fn tokenize_for_fts(text: &str) -> String {
+    JIEBA
+        .cut_for_search(text, true)
+        .into_iter()
+        .filter_map(normalize_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// 从自然语言问题中提取可用于 FTS/LIKE 的关键词。
+/// 搜索模式会同时给出较长词和适合检索的短词，随后去重并限制数量。
+pub fn extract_query_terms(query: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut terms = Vec::new();
+
+    for raw in JIEBA.cut_for_search(query, true) {
+        let Some(token) = normalize_token(raw) else {
+            continue;
+        };
+        if !is_significant_query_token(&token) || !seen.insert(token.clone()) {
+            continue;
+        }
+        terms.push(token);
+        if terms.len() >= 24 {
+            break;
+        }
+    }
+
+    terms
+}
+
+/// FTS5 查询使用 OR 组合关键词。相关度由候选内容的关键词覆盖率和 bm25
+/// 共同排序，不再要求用户整句原样出现在文档中。
+pub fn build_fts_query(query: &str) -> Option<(String, Vec<String>)> {
+    let terms = extract_query_terms(query);
+    if terms.is_empty() {
+        return None;
+    }
+
+    let expression = terms
+        .iter()
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+
+    Some((expression, terms))
+}
+
+pub fn keyword_coverage(content: &str, terms: &[String]) -> f32 {
+    if terms.is_empty() {
+        return 0.0;
+    }
+
+    let normalized_content = content.to_lowercase();
+    let matched = terms
+        .iter()
+        .filter(|term| normalized_content.contains(term.as_str()))
+        .count();
+    matched as f32 / terms.len() as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chinese_natural_question_extracts_real_keywords() {
+        let terms = extract_query_terms(
+            "根据教材，第16题中第二个 better 是什么词性、意思是什么？只按教材答案回答。",
+        );
+
+        assert!(terms.iter().any(|term| term == "better"));
+        assert!(terms.iter().any(|term| term == "词性"));
+        assert!(terms.iter().any(|term| term == "意思"));
+        assert!(!terms.iter().any(|term| term == "根据"));
+        assert!(!terms.iter().any(|term| term == "教材"));
+    }
+
+    #[test]
+    fn fts_query_uses_or_instead_of_exact_sentence() {
+        let (query, terms) = build_fts_query("第二个 better 的词性和意思").unwrap();
+
+        assert!(query.contains(" OR "));
+        assert!(query.contains("\"better\""));
+        assert!(terms.len() >= 3);
+    }
+
+    #[test]
+    fn coverage_rewards_the_chunk_containing_the_answer() {
+        let terms = extract_query_terms("第二个 better 的词性和意思");
+        let relevant = keyword_coverage("⑤ better（词性：动词；词义：改善，使更好）", &terms);
+        let irrelevant = keyword_coverage("spaceship 是由 space 和 ship 构成的合成词", &terms);
+
+        assert!(relevant > irrelevant);
+        assert!(relevant > 0.0);
+    }
+}

--- a/src-tauri/src/knowledge_base/types.rs
+++ b/src-tauri/src/knowledge_base/types.rs
@@ -136,6 +136,14 @@ pub struct RetrievalResult {
     pub query: String,
     pub chunks: Vec<RetrievedChunk>,
     pub total_chunks: i32,
+    #[serde(default)]
+    pub warnings: Vec<RetrievalWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrievalWarning {
+    pub code: String,
+    pub message: String,
 }
 
 /// 创建知识库的请求

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -32,6 +32,7 @@ import { useNotification } from "@/composables/useNotify";
 import { useSettingsStore } from "@/stores/settings";
 import { useChatStore } from "@/stores/chat";
 import { useWorkspaceStore } from "@/stores/workspace";
+import { useKnowledgeBaseStore } from "@/stores/knowledgeBase";
 
 // 导入快捷键匹配工具
 import { eventMatchesAccelerator } from "@/utils/hotkey";
@@ -55,6 +56,10 @@ const settings = useSettingsStore();
 
 // 聊天 Store
 const chat = useChatStore();
+
+// 知识库检索和 Reranker 可能在对话页、知识库页或后台流程中失败，
+// 统一由全局布局消费通知队列，确保始终显示在左下角。
+const knowledgeBase = useKnowledgeBaseStore();
 
 // 协作团队 Store：事件监听在这里（App 布局层）注册，而不是等用户第一次打开
 // 协作团队页面——否则 Agent 在别的页面提问/申请审批时整个应用毫无反应，
@@ -189,6 +194,31 @@ watch(
       }
     }
   }
+);
+
+watch(
+  () => knowledgeBase.retrievalNotices.length,
+  () => {
+    while (knowledgeBase.retrievalNotices.length > 0) {
+      const notice = knowledgeBase.retrievalNotices.shift();
+      if (!notice) continue;
+
+      if (notice.type === "error") {
+        criticalNotification.error({
+          title: notice.title,
+          description: notice.message,
+          duration: 8000,
+        });
+      } else {
+        notification.warning({
+          title: notice.title,
+          description: notice.message,
+          duration: 8000,
+        });
+      }
+    }
+  },
+  { immediate: true },
 );
 
 // 托盘/快捷键设置同步到后端失败时，同样走队列弹窗，别让用户以为设置已生效。

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -698,6 +698,48 @@ export const useChatStore = defineStore("chat", () => {
     }
   };
 
+  const buildEnhancedContent = async (
+    content: string,
+    documentContents?: Array<{ name: string; content: string }>,
+  ): Promise<string> => {
+    const contextParts: string[] = [];
+    lastRetrievalResult.value = null;
+
+    if (ragEnabled.value && selectedKnowledgeBaseId.value) {
+      const kbExists = kbStore.knowledgeBases.some(
+        kb => kb.id === selectedKnowledgeBaseId.value,
+      );
+      if (!kbExists) {
+        kbStore.retrievalNotices.push({
+          type: "error",
+          title: "知识库不可用",
+          message: "所选知识库不存在或已被删除，本次将不使用知识库内容。",
+        });
+      } else {
+        const result = await kbStore.searchKnowledgeBase(
+          selectedKnowledgeBaseId.value,
+          content,
+        );
+        if (result) {
+          // 空结果也要覆盖上一次状态，让界面明确显示“检索到 0 个片段”，
+          // 而不是继续展示上一轮的旧数量。
+          lastRetrievalResult.value = result;
+          const ragContext = buildRagContext(result);
+          if (ragContext) contextParts.push(ragContext);
+        }
+      }
+    }
+
+    if (documentContents && documentContents.length > 0) {
+      const docParts = documentContents.map(d => `[文档: ${d.name}]\n${d.content}`);
+      contextParts.push(`[用户附加文档]\n${docParts.join('\n---\n')}`);
+    }
+
+    return contextParts.length > 0
+      ? `${contextParts.join('\n\n')}\n\n问题：${content}`
+      : content;
+  };
+
   /**
    * 发送消息 (核心函数)
    * 处理用户消息发送、LLM 调用、流式响应等完整流程
@@ -718,39 +760,7 @@ export const useChatStore = defineStore("chat", () => {
     if (!currentSession.value) return;
     if (!resolveActiveConfig()) return;
 
-    // 初始化内容变量
-    let enhancedContent = content;
-
-    // ============ 文档上下文注入 ============
-    let docContext = "";
-    if (documentContents && documentContents.length > 0) {
-      const docParts = documentContents.map(d => `[文档: ${d.name}]\n${d.content}`);
-      docContext = `[用户附加文档]\n${docParts.join('\n---\n')}`;
-    }
-
-    // ============ RAG 检索增强 ============
-    let retrievalContext = "";
-    if (ragEnabled.value && selectedKnowledgeBaseId.value) {
-      const kb = kbStore.knowledgeBases.find(k => k.id === selectedKnowledgeBaseId.value);
-      if (kb) {
-        const result = await kbStore.searchKnowledgeBase(
-          selectedKnowledgeBaseId.value,
-          content
-        );
-        if (result && result.chunks.length > 0) {
-          lastRetrievalResult.value = result;
-          retrievalContext = buildRagContext(result);
-        }
-      }
-    }
-
-    // 合并上下文，构建最终发送内容
-    const contextParts: string[] = [];
-    if (retrievalContext) contextParts.push(retrievalContext);
-    if (docContext) contextParts.push(docContext);
-    if (contextParts.length > 0) {
-      enhancedContent = `${contextParts.join('\n\n')}\n\n问题：${content}`;
-    }
+    const enhancedContent = await buildEnhancedContent(content, documentContents);
 
     // 构建用户消息对象——聊天气泡展示原始输入，RAG/文档增强内容只通过
     // generateReply 的 contentOverride 参数注入发给模型的那份拷贝，不写进
@@ -831,7 +841,12 @@ export const useChatStore = defineStore("chat", () => {
     await saveMessageToDb(target);
     await saveSessionToDb();
 
-    await generateReply();
+    const enhancedContent = await buildEnhancedContent(trimmed);
+    await generateReply(
+      enhancedContent !== trimmed
+        ? { messageId: target.id, content: enhancedContent }
+        : undefined,
+    );
   };
 
   /**
@@ -853,7 +868,17 @@ export const useChatStore = defineStore("chat", () => {
     const removed = currentSession.value.messages.splice(idx);
     await deleteMessagesFromDb(removed);
 
-    await generateReply();
+    const lastUserMessage = [...currentSession.value.messages]
+      .reverse()
+      .find(message => message.role === "user");
+    if (!lastUserMessage) return;
+
+    const enhancedContent = await buildEnhancedContent(lastUserMessage.content);
+    await generateReply(
+      enhancedContent !== lastUserMessage.content
+        ? { messageId: lastUserMessage.id, content: enhancedContent }
+        : undefined,
+    );
   };
 
   /**

--- a/src/stores/knowledgeBase.ts
+++ b/src/stores/knowledgeBase.ts
@@ -21,6 +21,7 @@ import { defineStore } from "pinia";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useSettingsStore } from "./settings";
+import { classifyError } from "@/utils/errorMessage";
 
 // ============ 类型定义 (与 Rust 后端对应) ============
 
@@ -93,6 +94,18 @@ export interface RetrievalResult {
   query: string;                  // 检索查询文本
   chunks: RetrievedChunk[];       // 检索到的相关分块
   total_chunks: number;           // 符合阈值的总分块数
+  warnings?: RetrievalWarning[];  // 可回退错误，例如 Reranker 失败
+}
+
+export interface RetrievalWarning {
+  code: string;
+  message: string;
+}
+
+export interface KnowledgeBaseNotice {
+  type: "warning" | "error";
+  title: string;
+  message: string;
 }
 
 /**
@@ -129,6 +142,19 @@ export interface RetrievalSettings {
   rerankTopN?: number;            // 精排后保留条数（默认等于 topK）
 }
 
+export const MIN_SIMILARITY_THRESHOLD = 0.3;
+export const MAX_SIMILARITY_THRESHOLD = 0.8;
+export const DEFAULT_SIMILARITY_THRESHOLD = 0.5;
+const RETRIEVAL_SETTINGS_VERSION = 1;
+
+export const normalizeSimilarityThreshold = (value: number): number => {
+  const finiteValue = Number.isFinite(value) ? value : DEFAULT_SIMILARITY_THRESHOLD;
+  return Math.min(
+    MAX_SIMILARITY_THRESHOLD,
+    Math.max(MIN_SIMILARITY_THRESHOLD, finiteValue),
+  );
+};
+
 export const useKnowledgeBaseStore = defineStore("knowledgeBase", () => {
   // ============ 响应式状态 ============
   
@@ -146,14 +172,34 @@ export const useKnowledgeBaseStore = defineStore("knowledgeBase", () => {
   
   // 文档导入进度
   const importProgress = ref<{ current: number; total: number } | null>(null);
+
+  // Store 无法直接使用 Naive UI 的通知上下文，统一塞进队列，由 Layout 在
+  // 左下角弹出。Reranker 回退是 warning，完整检索失败是 error。
+  const retrievalNotices = ref<KnowledgeBaseNotice[]>([]);
   
   // 检索设置
   const retrievalSettings = ref<RetrievalSettings>({
     mode: "hybrid",
     topK: 5,
-    similarityThreshold: 0.7,
+    similarityThreshold: DEFAULT_SIMILARITY_THRESHOLD,
     enableReranker: false,
   });
+  const retrievalSettingsVersion = ref(0);
+
+  const migrateRetrievalSettings = () => {
+    if (retrievalSettingsVersion.value < RETRIEVAL_SETTINGS_VERSION) {
+      // 0.7 是旧版本的默认值，也正是这次把正确片段全部过滤掉的根因。
+      // 一次性迁移到 0.5；之后用户在新范围内的选择会原样保留。
+      if (Math.abs(retrievalSettings.value.similarityThreshold - 0.7) < 0.0001) {
+        retrievalSettings.value.similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
+      }
+      retrievalSettingsVersion.value = RETRIEVAL_SETTINGS_VERSION;
+    }
+
+    retrievalSettings.value.similarityThreshold = normalizeSimilarityThreshold(
+      retrievalSettings.value.similarityThreshold,
+    );
+  };
 
   // ============ 计算属性 ============
   
@@ -167,6 +213,7 @@ export const useKnowledgeBaseStore = defineStore("knowledgeBase", () => {
 
   // 加载所有知识库列表
   const loadKnowledgeBases = async () => {
+    migrateRetrievalSettings();
     loading.value = true;
     try {
       const result = await invoke<KnowledgeBase[]>("list_knowledge_bases");
@@ -321,6 +368,7 @@ export const useKnowledgeBaseStore = defineStore("knowledgeBase", () => {
     kbId: string,
     query: string,
   ): Promise<RetrievalResult | null> => {
+    migrateRetrievalSettings();
     try {
       // Build optional reranker params
       const rerankerParams: Record<string, unknown> = {};
@@ -343,20 +391,37 @@ export const useKnowledgeBaseStore = defineStore("knowledgeBase", () => {
           query,
           topK: retrievalSettings.value.topK,
           retrievalMode: retrievalSettings.value.mode,
-          similarityThreshold: retrievalSettings.value.similarityThreshold,
+          similarityThreshold: normalizeSimilarityThreshold(
+            retrievalSettings.value.similarityThreshold,
+          ),
           windowSize: 1, // fetch ±1 adjacent chunks to give LLM richer context
           ...rerankerParams,
         },
       });
+      for (const warning of result.warnings ?? []) {
+        retrievalNotices.value.push({
+          type: "warning",
+          title: warning.code === "reranker_fallback" ? "精排暂时不可用" : "知识库检索已降级",
+          message: warning.message,
+        });
+      }
       return result;
     } catch (error) {
       console.error("Failed to search knowledge base:", error);
+      retrievalNotices.value.push({
+        type: "error",
+        title: "知识库检索失败",
+        message: `${classifyError(error).message}。本次将不使用知识库内容。`,
+      });
       return null;
     }
   };
 
   const updateRetrievalSettings = (settings: Partial<RetrievalSettings>) => {
     retrievalSettings.value = { ...retrievalSettings.value, ...settings };
+    retrievalSettings.value.similarityThreshold = normalizeSimilarityThreshold(
+      retrievalSettings.value.similarityThreshold,
+    );
   };
 
   // Format file size
@@ -388,6 +453,8 @@ export const useKnowledgeBaseStore = defineStore("knowledgeBase", () => {
     loading,
     importProgress,
     retrievalSettings,
+    retrievalSettingsVersion,
+    retrievalNotices,
     
     // Getters
     currentKbDocuments,
@@ -408,6 +475,6 @@ export const useKnowledgeBaseStore = defineStore("knowledgeBase", () => {
   };
 }, {
   persist: {
-    paths: ["retrievalSettings"],
+    paths: ["retrievalSettings", "retrievalSettingsVersion"],
   },
 });

--- a/src/utils/errorMessage.ts
+++ b/src/utils/errorMessage.ts
@@ -22,6 +22,15 @@ export function classifyError(error: unknown): ClassifiedError {
 
   if (errorStr.includes("API key") || errorStr.includes("Unauthorized") || errorStr.includes("401")) {
     return { type: "auth", message: "API 密钥无效或已过期，请检查设置" };
+  } else if (errorStr.includes("Embedding error")) {
+    return {
+      type: "embedding",
+      message: "生成检索向量失败，请检查知识库关联的 Embedding 配置后重试",
+    };
+  } else if (errorStr.includes("Knowledge base not found")) {
+    return { type: "knowledge_base", message: "所选知识库不存在或已被删除，请重新选择" };
+  } else if (errorStr.includes("Retrieval error")) {
+    return { type: "retrieval", message: "知识库检索服务暂时不可用，请检查配置后重试" };
   } else if (errorStr.includes("network") || errorStr.includes("Failed to fetch")) {
     return { type: "network", message: "网络连接错误，请检查网络设置" };
   } else if (errorStr.includes("timeout")) {

--- a/src/views/KnowledgeBaseView.vue
+++ b/src/views/KnowledgeBaseView.vue
@@ -68,7 +68,13 @@ import {
   Library,
 } from "@vicons/ionicons5";
 import { useMessage } from "@/composables/useNotify";
-import { useKnowledgeBaseStore, type KnowledgeBase, type Document } from "@/stores/knowledgeBase";
+import {
+  useKnowledgeBaseStore,
+  MIN_SIMILARITY_THRESHOLD,
+  MAX_SIMILARITY_THRESHOLD,
+  type KnowledgeBase,
+  type Document,
+} from "@/stores/knowledgeBase";
 import { useSettingsStore } from "@/stores/settings";
 
 // ============ 状态管理 ============
@@ -728,8 +734,8 @@ const getStatusTag = (status: Document["status"]) => {
               <div class="slider-row">
                 <n-slider
                   v-model:value="kbStore.retrievalSettings.similarityThreshold"
-                  :min="0"
-                  :max="1"
+                  :min="MIN_SIMILARITY_THRESHOLD"
+                  :max="MAX_SIMILARITY_THRESHOLD"
                   :step="0.05"
                   show-tooltip
                 />


### PR DESCRIPTION
## 修复内容

- 将默认相似度阈值调整为 0.5，并限制在 0.3–0.8；旧版默认值 0.7 自动迁移。
- 为中文关键词检索加入分词、OR 查询、覆盖率/BM25 排序与 LIKE 回退；旧 FTS 索引会自动重建，无需重新生成 Embedding。
- Reranker 失败时保留原始检索结果，并通过既有左下角通知提示降级。
- 检索失败进入既有左下角中文错误提示。
- 发送、编辑后重新回答、重新生成都会重新执行 RAG 检索，避免沿用旧上下文。

## 根因

中文自然语言问题被原有的空格切分与 porter FTS 索引当作整句匹配；同时默认阈值 0.7 会过滤掉实际相关片段。Reranker 失败还会错误清空已检索到的结果。

## 用户影响

启用知识库后，中文教材类问题可命中相关片段并注入回答上下文；检索或精排异常会明确提示且保留可用降级结果。

## 验证

- `cargo test --bin BaiyuAISpace2 knowledge_base -- --nocapture`：8/8 通过
- `pnpm build`：通过
- `cargo build`：通过
- 真实应用回归：原教材问题检索到 4 个片段，包含“⑤ better：动词；改善/使更好”；检索失败和 Reranker 降级通知均已验证。
- `pnpm tauri build` 已完成 release 编译和 NSIS 打包；仅因本机未配置 `TAURI_SIGNING_PRIVATE_KEY` 在更新器签名阶段退出。