### PR TITLE
feat: 接入真实 Token Usage 统计

### DIFF
--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -79,6 +79,16 @@ pub struct ChatMessage {
     /// 视频附件 (仅 Gemini provider 有效, 其他 provider 忽略)
     #[serde(default)]
     pub videos: Vec<VideoAttachment>,
+    #[serde(default)]
+    pub token_usage: Option<TokenUsage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
 }
 
 /// 聊天会话结构
@@ -184,6 +194,14 @@ pub struct StreamChunk {
     pub is_thinking: bool,
     /// 是否完成
     pub done: bool,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenUsageEvent {
+    pub session_id: String,
+    pub message_id: String,
+    pub usage: TokenUsage,
 }
 
 // 每个正在进行的流对应一个取消令牌，以 session_id 为键，
@@ -524,6 +542,7 @@ fn build_stream_request_body(provider: &str, model: &str, messages: &[ChatMessag
                 "model": model,
                 "messages": msgs,
                 "stream": true,
+                "stream_options": { "include_usage": true },
             });
 
             // 未设置时直接省略字段，而不是拿一个猜测值去顶替；这些 provider 并不
@@ -956,6 +975,9 @@ fn parse_sse_line(provider: &str, line: &str) -> Option<StreamContent> {
         }
         _ => {
             // OpenAI 格式
+            if let Some(usage) = parse_openai_usage(&json) {
+                return Some(StreamContent::Usage(usage));
+            }
             if let Some(choices) = json["choices"].as_array() {
                 if let Some(first_choice) = choices.first() {
                     let delta = &first_choice["delta"];
@@ -1020,7 +1042,17 @@ enum StreamContent {
     /// 思考型模型的思考过程增量（reasoning/reasoning_content/thinking_delta）
     Thinking(String),
     ToolCallDeltas(Vec<ToolCallDelta>),
+    Usage(TokenUsage),
     Done,
+}
+
+fn parse_openai_usage(json: &serde_json::Value) -> Option<TokenUsage> {
+    let usage = json.get("usage")?;
+    Some(TokenUsage {
+        prompt_tokens: usage.get("prompt_tokens")?.as_u64()?,
+        completion_tokens: usage.get("completion_tokens")?.as_u64()?,
+        total_tokens: usage.get("total_tokens")?.as_u64()?,
+    })
 }
 
 /// 流式工具调用的一个片段，以 `index` 为键。`id`/`name` 只出现在某个 index
@@ -1156,6 +1188,7 @@ pub async fn stream_message(
                     error: None,
                     images: vec![],
                     videos: vec![],
+                    token_usage: None,
                 });
             }
         }
@@ -1282,6 +1315,13 @@ pub async fn stream_message(
                                                 entry.arguments.push_str(&fragment);
                                             }
                                         }
+                                    }
+                                    StreamContent::Usage(usage) => {
+                                        let _ = app_handle.emit("token-usage", TokenUsageEvent {
+                                            session_id: request.session_id.clone(),
+                                            message_id: message_id.clone(),
+                                            usage,
+                                        });
                                     }
                                     StreamContent::Done => {
                                         return finalize_turn(
@@ -2567,7 +2607,7 @@ mod provider_tool_calling_tests {
     fn anthropic_request_body_carries_tools_in_anthropic_shape() {
         let messages = vec![ChatMessage {
             id: "1".into(), role: "user".into(), content: "hi".into(),
-            timestamp: 0, error: None, images: vec![], videos: vec![],
+            timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None,
         }];
         let body = build_stream_request_body("anthropic", "claude-3-5-sonnet", &messages, &[sample_tool()], false, None);
         let tools = body["tools"].as_array().expect("tools should be an array");
@@ -2580,7 +2620,7 @@ mod provider_tool_calling_tests {
     fn msg(role: &str, content: &str) -> ChatMessage {
         ChatMessage {
             id: content.into(), role: role.into(), content: content.into(),
-            timestamp: 0, error: None, images: vec![], videos: vec![],
+            timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None,
         }
     }
 
@@ -2624,7 +2664,7 @@ mod provider_tool_calling_tests {
     fn google_request_body_groups_tools_under_function_declarations() {
         let messages = vec![ChatMessage {
             id: "1".into(), role: "user".into(), content: "hi".into(),
-            timestamp: 0, error: None, images: vec![], videos: vec![],
+            timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None,
         }];
         let body = build_stream_request_body("google", "gemini-1.5-pro", &messages, &[sample_tool()], false, None);
         let tools = body["tools"].as_array().expect("tools should be an array");
@@ -2706,12 +2746,25 @@ mod provider_tool_calling_tests {
     fn openai_shape_unaffected_by_provider_branching() {
         let messages = vec![ChatMessage {
             id: "1".into(), role: "user".into(), content: "hi".into(),
-            timestamp: 0, error: None, images: vec![], videos: vec![],
+            timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None,
         }];
         let body = build_stream_request_body("openai", "gpt-4o", &messages, &[sample_tool()], false, None);
         let tools = body["tools"].as_array().expect("tools should be an array");
         assert_eq!(tools[0]["type"], "function");
         assert_eq!(tools[0]["function"]["name"], "get_weather");
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn openai_usage_chunk_is_parsed_before_empty_choices() {
+        let parsed = parse_sse_line(
+            "openai",
+            r#"data: {"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":8,"total_tokens":20}}"#,
+        );
+        match parsed {
+            Some(StreamContent::Usage(usage)) => assert_eq!(usage.total_tokens, 20),
+            _ => panic!("expected OpenAI usage chunk"),
+        }
     }
 
     #[test]
@@ -2770,7 +2823,7 @@ mod provider_tool_calling_tests {
     fn local_providers_get_reasoning_effort_none_only_when_thinking_disabled() {
         let messages = vec![ChatMessage {
             id: "1".into(), role: "user".into(), content: "hi".into(),
-            timestamp: 0, error: None, images: vec![], videos: vec![],
+            timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None,
         }];
 
         // 本地服务 + 思考关闭：显式关思考（LM Studio 上 qwen3.5 这类默认思考
@@ -2801,6 +2854,7 @@ mod provider_tool_calling_tests {
             timestamp: 0, error: None,
             images: vec![ImageAttachment { data: "AAAA".into(), media_type: "image/png".into() }],
             videos: vec![],
+            token_usage: None,
         }
     }
 
@@ -2885,9 +2939,9 @@ mod provider_tool_calling_tests {
     #[test]
     fn build_native_messages_matches_provider_shapes() {
         let messages = vec![
-            ChatMessage { id: "0".into(), role: "system".into(), content: "be nice".into(), timestamp: 0, error: None, images: vec![], videos: vec![] },
-            ChatMessage { id: "1".into(), role: "user".into(), content: "hi".into(), timestamp: 0, error: None, images: vec![], videos: vec![] },
-            ChatMessage { id: "2".into(), role: "assistant".into(), content: "hello".into(), timestamp: 0, error: None, images: vec![], videos: vec![] },
+            ChatMessage { id: "0".into(), role: "system".into(), content: "be nice".into(), timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None },
+            ChatMessage { id: "1".into(), role: "user".into(), content: "hi".into(), timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None },
+            ChatMessage { id: "2".into(), role: "assistant".into(), content: "hello".into(), timestamp: 0, error: None, images: vec![], videos: vec![], token_usage: None },
         ];
 
         let anthropic = build_native_messages("anthropic", &messages);

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -104,11 +104,21 @@ impl Database {
                 content TEXT NOT NULL,
                 timestamp INTEGER NOT NULL,
                 error TEXT,
+                token_usage TEXT,
                 FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
             )
             "#,
             [],
         )?;
+
+        let has_token_usage = self.conn.query_row(
+            "SELECT 1 FROM pragma_table_info('messages') WHERE name = 'token_usage'",
+            [],
+            |_| Ok(true),
+        ).unwrap_or(false);
+        if !has_token_usage {
+            self.conn.execute("ALTER TABLE messages ADD COLUMN token_usage TEXT", [])?;
+        }
 
         self.conn.execute(
             r#"
@@ -283,21 +293,24 @@ impl Database {
         session_id: &str,
         message: &ChatMessage,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let token_usage = message.token_usage.as_ref().map(serde_json::to_string).transpose()?;
         self.conn.execute(
             r#"
-            INSERT INTO messages (id, session_id, role, content, timestamp, error)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO messages (id, session_id, role, content, timestamp, error, token_usage)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 content = excluded.content,
-                error = excluded.error
+                error = excluded.error,
+                token_usage = excluded.token_usage
             "#,
-            [
-                &message.id,
+            rusqlite::params![
+                message.id,
                 session_id,
-                &message.role,
-                &message.content,
-                &message.timestamp.to_string(),
-                &message.error.as_deref().unwrap_or(""),
+                message.role,
+                message.content,
+                message.timestamp,
+                message.error.as_deref().unwrap_or(""),
+                token_usage,
             ],
         )?;
 
@@ -341,7 +354,7 @@ impl Database {
         
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT id, role, content, timestamp, error 
+            SELECT id, role, content, timestamp, error, token_usage
             FROM messages 
             WHERE session_id = ? 
             ORDER BY timestamp ASC
@@ -350,6 +363,7 @@ impl Database {
         
         let rows = stmt.query_map([session_id], |row| {
             let error: Option<String> = row.get(4)?;
+            let token_usage_json: Option<String> = row.get(5)?;
             Ok(ChatMessage {
                 id: row.get(0)?,
                 role: row.get(1)?,
@@ -358,6 +372,7 @@ impl Database {
                 error: if error.as_deref() == Some("") { None } else { error },
                 images: vec![],
                 videos: vec![],
+                token_usage: token_usage_json.as_deref().and_then(|value| serde_json::from_str(value).ok()),
             })
         })?;
 

--- a/src-tauri/src/workspace/commands.rs
+++ b/src-tauri/src/workspace/commands.rs
@@ -1295,6 +1295,7 @@ async fn process_agent_wake(
                     error: None,
                     images: vec![],
                     videos: vec![],
+                    token_usage: None,
                 };
                 native_messages.extend(build_native_messages(&agent.provider, std::slice::from_ref(&rescue_hint)));
 
@@ -1478,6 +1479,7 @@ async fn process_agent_wake(
                         error: None,
                         images: vec![],
                         videos: vec![],
+                        token_usage: None,
                     };
                     native_messages.extend(build_native_messages(&agent.provider, std::slice::from_ref(&warn)));
                 }
@@ -1506,6 +1508,7 @@ async fn process_agent_wake(
             error: None,
             images: vec![],
             videos: vec![],
+            token_usage: None,
         };
         native_messages.extend(build_native_messages(&agent.provider, std::slice::from_ref(&nudge)));
 
@@ -1647,6 +1650,7 @@ async fn build_chat_history(app_handle: &AppHandle, workspace_id: &str, agent: &
                 // （build_native_messages 只对 user 角色构造多模态块）
                 images: m.images,
                 videos: vec![],
+                token_usage: None,
             }
         })
         .collect()

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -32,7 +32,6 @@ import { NAvatar, NIcon, NSpin, NAlert, NTooltip } from "naive-ui";
 // 的截断/删除逻辑都在 store 里，组件只负责触发
 import { useChatStore } from "@/stores/chat";
 import TokenCount from "@/components/TokenCount.vue";
-import { estimateTokenCount } from "@/utils/tokenCount";
 
 // Markdown 渲染管线。marked/KaTeX/DOMPurify/hljs/Mermaid 的全局配置都在该
 // 模块顶层完成，整个应用只执行一次——不能放回本组件的 <script setup>：
@@ -161,9 +160,6 @@ const isAssistant = computed(() => props.message.role === "assistant");
 // 渲染后的 Markdown 内容（解析、净化、HTML/Mermaid 预览块生成全部在
 // utils/markdown.ts 的 renderMarkdown 里完成）
 const renderedContent = computed(() => renderMarkdown(props.message.content));
-
-// 流式输出期间也随正文实时更新；只统计消息可见文本。
-const messageTokenCount = computed(() => estimateTokenCount(props.message.content));
 
 // ============ 方法函数 ============
 
@@ -415,8 +411,12 @@ const handleRegenerate = async () => {
       </div>
 
       <TokenCount
+        v-if="message.tokenUsage"
         class="message-token-count"
-        :count="messageTokenCount"
+        label="本次"
+        :count="message.tokenUsage.totalTokens"
+        :exact="true"
+        :description="`输入 ${message.tokenUsage.promptTokens} · 输出 ${message.tokenUsage.completionTokens} · 服务端实际 Usage`"
       />
 
       <!-- Actions -->

--- a/src/components/TokenCount.vue
+++ b/src/components/TokenCount.vue
@@ -10,9 +10,11 @@ const props = withDefaults(defineProps<{
   count: number;
   label?: string;
   description?: string;
+  exact?: boolean;
 }>(), {
   label: "",
   description: "估算值，仅统计可见文本；不含图片、隐藏系统提示词和工具上下文",
+  exact: false,
 });
 
 const formattedCount = computed(() => formatTokenCount(props.count));
@@ -27,7 +29,7 @@ const formattedCount = computed(() => formatTokenCount(props.count));
       v-if="label"
       class="token-label"
     >{{ label }}</span>
-    <span class="token-value">≈ {{ formattedCount }} Tokens</span>
+    <span class="token-value">{{ exact ? "" : "≈ " }}{{ formattedCount }} Tokens</span>
   </span>
 </template>
 

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -46,6 +46,13 @@ export interface Message {
   images?: ImageAttachment[];     // 图片附件（已转 base64）
   videos?: VideoAttachment[];     // 视频附件（已转 base64，仅 Gemini）
   toolCalls?: ToolCallInfo[];     // 本轮回复中触发的工具调用（按发生顺序）
+  tokenUsage?: TokenUsage;        // 服务端返回的本次交互真实 Token 用量
+}
+
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
 }
 
 /** 单次工具调用的状态信息，用于在消息里展示"正在调用/已完成/失败" */
@@ -84,6 +91,12 @@ interface StreamChunk {
   done: boolean;                  // 是否完成
 }
 
+interface TokenUsageEvent {
+  sessionId: string;
+  messageId: string;
+  usage: TokenUsage;
+}
+
 /**
  * 工具调用状态事件类型
  * 从后端接收的 tool-call-status 事件数据结构
@@ -108,6 +121,7 @@ interface DbMessage {
   content: string;
   timestamp: number;
   error?: string;
+  token_usage?: TokenUsage;
 }
 
 /**
@@ -161,6 +175,7 @@ export const useChatStore = defineStore("chat", () => {
 
   /** 工具调用状态事件监听器取消函数 */
   let unlistenToolCallFn: UnlistenFn | null = null;
+  let unlistenTokenUsageFn: UnlistenFn | null = null;
 
   /** RAG (检索增强生成) 是否启用 */
   const ragEnabled = ref(false);
@@ -213,6 +228,7 @@ export const useChatStore = defineStore("chat", () => {
           content: m.content,
           timestamp: m.timestamp,
           error: m.error,
+          tokenUsage: m.token_usage,
         })),
       }));
       console.log("[Chat] sessions.value updated, first session messages:", sessions.value[0]?.messages?.length);
@@ -354,6 +370,18 @@ export const useChatStore = defineStore("chat", () => {
     });
   };
 
+  /** 将后端最终 SSE chunk 中的 usage 绑定到本轮 assistant 消息。 */
+  const setupTokenUsageListener = async () => {
+    if (unlistenTokenUsageFn) unlistenTokenUsageFn();
+    unlistenTokenUsageFn = await listen<TokenUsageEvent>("token-usage", (event) => {
+      const usageEvent = event.payload;
+      if (!currentSession.value || String(usageEvent.sessionId) !== String(currentSession.value.id)) return;
+      const message = currentSession.value.messages.find(m => m.id === usageEvent.messageId)
+        ?? [...currentSession.value.messages].reverse().find(m => m.role === "assistant");
+      if (message) message.tokenUsage = usageEvent.usage;
+    });
+  };
+
   /**
    * 保存当前会话到数据库
    * 包含会话基本信息，不包含消息内容
@@ -397,6 +425,7 @@ export const useChatStore = defineStore("chat", () => {
         content: message.content,
         timestamp: message.timestamp,
         error: message.error,
+        token_usage: message.tokenUsage,
       };
       await invoke("save_message_cmd", {
         sessionId: currentSession.value.id,
@@ -451,6 +480,7 @@ export const useChatStore = defineStore("chat", () => {
     // 否则每次点"新建对话"都会在历史记录里留下一条"新对话/0条消息"的僵尸记录
     await setupStreamListener();
     await setupToolCallListener();
+    await setupTokenUsageListener();
 
     return session;
   };
@@ -505,6 +535,7 @@ export const useChatStore = defineStore("chat", () => {
     console.log("[Chat] currentSession set, messages:", currentSession.value?.messages?.length);
     await setupStreamListener();
     await setupToolCallListener();
+    await setupTokenUsageListener();
   };
 
   /**

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -25,7 +25,6 @@ import { useSettingsStore } from "@/stores/settings";
 import ChatMessage from "@/components/ChatMessage.vue";
 import ChatInput from "@/components/ChatInput.vue";
 import TokenCount from "@/components/TokenCount.vue";
-import { countMessageTokens } from "@/utils/tokenCount";
 
 // ============ 状态管理 ============
 
@@ -48,9 +47,12 @@ const hasMessages = computed(() => {
   return chat.currentSession && chat.currentSession.messages.length > 0;
 });
 
-/** 当前会话全部可见消息的文本 Token 估算，流式输出时实时增长。 */
+/** 已完成交互由服务端返回的实际总用量；未返回 usage 的旧会话不纳入。 */
 const sessionTokenCount = computed(() =>
-  countMessageTokens(chat.currentSession?.messages ?? [])
+  (chat.currentSession?.messages ?? []).reduce(
+    (total, message) => total + (message.tokenUsage?.totalTokens ?? 0),
+    0,
+  )
 );
 
 // ============ 方法函数 ============
@@ -113,10 +115,12 @@ onMounted(async () => {
       v-if="chat.currentSession"
       class="session-token-bar"
     >
-      <span class="session-token-eyebrow">Session Context</span>
+      <span class="session-token-eyebrow">Session Usage</span>
       <TokenCount
-        label="本会话"
+        label="累计"
         :count="sessionTokenCount"
+        :exact="true"
+        description="已完成交互的 API 实际 total_tokens 累计；未返回 Usage 的交互不计入"
       />
     </div>
 


### PR DESCRIPTION
## 更新内容

- 为 OpenAI 兼容流式请求启用 `stream_options.include_usage`，解析流末尾的 Usage 数据。
- 将每次交互的输入、输出与总 Token 持久化，并在消息旁展示准确总数。
- 在会话顶部汇总已返回的 Usage Token；旧会话保持兼容。

## 验证

- `pnpm build`
- `cargo build`
- `cargo test openai_usage_chunk_is_parsed_before_empty_choices`
- 真实桌面 UI：当前 OpenAI 兼容配置请求“只回复：OK”，界面显示本次 `219 Tokens`、累计 `219 Tokens`。